### PR TITLE
Allow code to compile with Apple's Clang compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(SOURCES
 )
 
 # Remove flags that break mac compilation with g++-13
-add_compile_options("-Ofast" "-ffast-math" "-fno-finite-math-only" "-fsigned-zeros" "-fno-associative-math" "-fno-inline" "-march=native" "-mtune=native" "-funroll-loops" "-floop-unroll-and-jam" "-fomit-frame-pointer" "-finline" "-ftree-vectorize")
+add_compile_options("-Ofast" "-ffast-math" "-fno-finite-math-only" "-fsigned-zeros" "-fno-associative-math" "-fno-inline" "-march=native" "-mtune=native" "-funroll-loops" "-fomit-frame-pointer" "-finline" "-ftree-vectorize")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 #    add_compile_options()
 else()

--- a/src/lib/PDF.cpp
+++ b/src/lib/PDF.cpp
@@ -29,17 +29,17 @@ PDF::PDF(const double min, const double max, const size_t size){
   scaleMin = min;
   scaleMax = max;
   vsize = size;
-  xaxis.assign(size,0.d);
+  xaxis.assign(size,0.0);
   scaleStep = (max-min)/(vsize-1);
   for(size_t k=0; k<vsize; k++) {
     xaxis[k] = min + double(k)*scaleStep;
   }
-  vPDF.assign(vsize, 0.d);
+  vPDF.assign(vsize, 0.0);
   chi2.assign(vsize, HIGH_CHI2);
   // Index of the SED corresponding to the minima or mode
-  ind.assign(vsize, 0.d);
+  ind.assign(vsize, 0.0);
   // Store the inverse of scale step for computational time
-  invScaleStep = 1.d/scaleStep;
+  invScaleStep = 1.0/scaleStep;
   
   return;
 }
@@ -217,7 +217,7 @@ pair<double, double> PDF::credible_interval(float level,double val){
   // Compute the full cumulant
   vector<double> cumulant;
   double tmp=0;
-  cumulant.push_back(0.d);
+  cumulant.push_back(0.0);
   for(size_t k=0; k<xaxis.size()-1;k++){
     tmp += (xaxis[k+1]-xaxis[k])*(vPDF[k+1]+vPDF[k])/2.;
     cumulant.push_back(tmp);
@@ -295,7 +295,7 @@ double PDF::levelCumu2x(float level){
   // Compute the full cumulant
   vector<double> cumulant;
   double tmp=0;
-  cumulant.push_back(0.d);
+  cumulant.push_back(0.0);
   for(size_t k=0; k<xaxis.size()-1;k++){
     tmp += (xaxis[k+1]-xaxis[k])*(vPDF[k+1]+vPDF[k])/2.;
     cumulant.push_back(tmp);

--- a/src/lib/SED.cpp
+++ b/src/lib/SED.cpp
@@ -353,7 +353,7 @@ vector<double> SED::integrateSED(const flt& filter) {
 // Integral of lamb_flux with the trapezoidal method
 double SED::trapzd() {
 
-  double s=0.D;
+  double s=0.0;
   for(size_t k=0; k<lamb_flux.size()-1; k++){
     s += (lamb_flux[k+1].val + lamb_flux[k].val) * 0.5 * (lamb_flux[k+1].lamb - lamb_flux[k].lamb);
   }
@@ -575,7 +575,7 @@ void SED::generate_spectra(double zin, double dmin, vector<opa> opaAll)
     SEDz0_Em.lamb_flux.clear();
     SEDz0_Em.generateEmSpectra(40);
     // Add them to the continuum
-    sumSpectra(SEDz0_Em,1.D);   
+    sumSpectra(SEDz0_Em,1.0);   
     // Opacity applied in rest-frame, depending on the redshift of the source
     applyOpa(opaAll);
     // Redshift the SED at the redshift extracted from the minimum chi2
@@ -1294,7 +1294,7 @@ pair<vector<double>, vector<double> > SED::get_data_vector(double minl, double m
     lambs.push_back(lamb) ;
     
     if( mag ) {
-      val = val<=0.d ? HIGH_MAG : flux2mag(val*lamb*lamb/c, offset);
+      val = val<=0.0 ? HIGH_MAG : flux2mag(val*lamb*lamb/c, offset);
     }
     
     vals.push_back(val);
@@ -1829,7 +1829,7 @@ void SED::compute_magnitudes(const vector<flt>& filters) {
     // Derive the AB magnitudes in each filter
     vector<double> intFlux = integrateSED(filter);
     if(intFlux[3] != INVALID_VAL){ 
-      if(intFlux[3]>0.d){
+      if(intFlux[3]>0.0){
 	val = -2.5*LOG10D(intFlux[3]/intFlux[1] * filter.fcorr) - 48.6 + distMod;
       }else val = HIGH_MAG;
     }else val = INVALID_MAG;

--- a/src/lib/SED.h
+++ b/src/lib/SED.h
@@ -161,14 +161,14 @@ public:
    */
   virtual void calc_ph(){}; // Number of inoizing photons
   virtual void SEDproperties(){};
-  void generate_spectra(double zin=0.d, double dmin=1.d, vector<opa> opaAll={});
+  void generate_spectra(double zin=0.0, double dmin=1.0, vector<opa> opaAll={});
   
   //in read_lib for zphota
   virtual void clean(){lamb_flux.clear();mag.clear();kcorr.clear();fac_line.clear();};
   virtual void setOthers(){};
   void fit_normalization(const onesource& source, const int imagm);
   inline bool is_same_model(const SED& other) {return ((*this).nummod == other.nummod && (*this).ebv == other.ebv && (*this).age == other.age) ;}
-  pair<vector<double>, vector<double> > get_data_vector(double, double, bool, double offset=0.d);
+  pair<vector<double>, vector<double> > get_data_vector(double, double, bool, double offset=0.0);
   
   void redshift();
   void applyExt(const double ebv, const ext& oneext);

--- a/src/lib/globals.h
+++ b/src/lib/globals.h
@@ -7,14 +7,14 @@
 #include <bitset>
 
 #define MAX_CONTEXT 1024
-#define INVALID_FLUX -9999.d
-#define INVALID_VAL -9999.d
-#define INVALID_MAG -9999.d
-#define INVALID_PHYS -999.d
-#define NULL_FLUX 0.d
-#define HIGH_MAG 1000.d
-#define HIGH_CHI2 1.e9d
-#define EPS_Z 1.e-10d
+#define INVALID_FLUX -9999.0
+#define INVALID_VAL -9999.0
+#define INVALID_MAG -9999.0
+#define INVALID_PHYS -999.0
+#define NULL_FLUX 0.0
+#define HIGH_MAG 1000.0
+#define HIGH_CHI2 1.0e9
+#define EPS_Z 1.0e-10
 
 using namespace std;
 
@@ -44,8 +44,8 @@ int  bdincl(int n,long cont,int max);
 inline string bool2string(const bool & b) {string sb; b?sb="YES": sb="NO"; return sb;}
 
 inline bool CHECK_CONTEXT_BIT(unsigned long context, unsigned int n) {return std::bitset<MAX_CONTEXT>(context).test(n);}
-inline double POW10D(double x) {return exp(2.302585092994046d*x);}
-inline double POW10DSLOW(double x) {return pow(10.d,x);}
+inline double POW10D(double x) {return exp(2.302585092994046*x);}
+inline double POW10DSLOW(double x) {return pow(10.0,x);}
 // This is a fast approximation to log2()
 // Y = C[0]*F*F*F + C[1]*F*F + C[2]*F + C[3] + E;
 inline double log2f_approx(double X) {
@@ -65,6 +65,6 @@ inline double log2f_approx(double X) {
 #define LOG10D LOG10D_SLOW
 inline double LOG10D_SLOW(double x) {return log10(x);}
 inline double LOG10D_FAST(double x) {return log2f_approx(x)*0.3010299956639812f;}
-inline double mag2flux(double x, double zp=0.d) {return POW10D(-0.4d*(x + 48.6d - zp));}
-inline double flux2mag(double x, double offset=0.d) {return -2.5d*LOG10D(x) - 48.6d + offset;}
+inline double mag2flux(double x, double zp=0.0) {return POW10D(-0.4*(x + 48.6 - zp));}
+inline double flux2mag(double x, double offset=0.0) {return -2.5*LOG10D(x) - 48.6 + offset;}
 #endif

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -393,9 +393,9 @@ void onesource::fit(vector<SED*> &fulllib,const vector<vector<double>> &flux, co
   // invsab = busnorma / sab
   // busnorma here ensures that all the precomputed values will be 0 if busnorma=0
   // (aka not to be used in fit)
-  vector<double>   s2n(imagm, 0.d), invsab(imagm, 0.d),invsabSq(imagm, 0.d), abinvsabSq(imagm, 0.d);
+  vector<double>   s2n(imagm, 0.0), invsab(imagm, 0.0),invsabSq(imagm, 0.0), abinvsabSq(imagm, 0.0);
   for(size_t i=0; i<imagm;i++){
-    invsab[i] = busnorma[i] * 1.d/sab[i];
+    invsab[i] = busnorma[i] * 1.0/sab[i];
   }
   for(size_t i=0; i<imagm;i++){
     invsabSq[i] = invsab[i] * invsab[i];
@@ -616,7 +616,7 @@ double onesource::nzprior(const double luv, const double lnir,const double reds,
   double rapp=ft[mod]*exp(-ktf[mod]*(mi-20.0));
 
   // Normalisation of the probability function
-  // pcal=exp(gammln(1.d0/alpt0(mod)+1.d0))
+  // pcal=exp(gammln(1.0/alpt0(mod)+1.0))
   double pcal;
   if(mod==0)pcal=  0.89744;  
   if(mod==1)pcal=  0.90868;  
@@ -718,7 +718,7 @@ void onesource::fitIR(vector<SED*> &fulllibIR,const vector<vector<double>> &flux
   
         // normalization
         // Measurement of scaling factor dm only with (fobs>flim), dchi2/ddm = 0
-        double avmago=0.d, avmagt=0.d, dmloc=-99.d;
+        double avmago=0.0, avmagt=0.0, dmloc=-99.0;
         int nbusIR=0;
 	nbusIR = accumulate(bscfir.begin(), bscfir.end(), 0);
         for (int k=0; k<imagm; k++){
@@ -815,17 +815,37 @@ void onesource::generatePDF(vector<SED*> &fulllib, const vector<size_t> &va, con
   double prob;
   // need to convert into 1 dimension array for openMP reduction
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] / 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] / 11:["BAY_ZG"] / 12:["BAY_ZQ"]
-  double PDFzloc[pdfmap[11].size()]={0.};
-  double PDFzqloc[pdfmap[12].size()]={0.};
-  double PDFmassloc[pdfmap[0].size()]={0.};
-  double PDFSFRloc[pdfmap[1].size()]={0.};
-  double PDFsSFRloc[pdfmap[2].size()]={0.};
-  double PDFAgeloc[pdfmap[5].size()]={0.};
-  double PDFLdustloc[pdfmap[3].size()]={0.};
-  double PDFcol1loc[ pdfmap[6].size() ]={0.};
-  double PDFcol2loc[ pdfmap[7].size() ]={0.};
-  double PDFmrefloc[ pdfmap[8].size() ]={0.};
-    
+  double PDFzloc[pdfmap[11].size()];
+  for (int i=0; i<pdfmap[11].size(); ++i) PDFzloc[i] = 0.0;
+
+  double PDFzqloc[pdfmap[12].size()];
+  for (int i=0; i<pdfmap[12].size(); ++i) PDFzqloc[i] = 0.0;
+
+  double PDFmassloc[pdfmap[0].size()];
+  for (int i=0; i<pdfmap[0].size(); ++i) PDFmassloc[i] = 0.0;
+
+  double PDFSFRloc[pdfmap[1].size()];
+  for (int i=0; i<pdfmap[1].size(); ++i) PDFSFRloc[i] = 0.0;
+  
+  double PDFsSFRloc[pdfmap[2].size()];
+  for (int i=0; i<pdfmap[2].size(); ++i) PDFsSFRloc[i] = 0.0;
+  
+  double PDFAgeloc[pdfmap[5].size()];
+  for (int i=0; i<pdfmap[5].size(); ++i) PDFAgeloc[i] = 0.0;
+  
+  double PDFLdustloc[pdfmap[3].size()];
+  for (int i=0; i<pdfmap[3].size(); ++i) PDFLdustloc[i] = 0.0;
+  
+  double PDFcol1loc[ pdfmap[6].size() ];
+  for (int i=0; i<pdfmap[6].size(); ++i) PDFcol1loc[i] = 0.0;
+  
+  double PDFcol2loc[ pdfmap[7].size() ];
+  for (int i=0; i<pdfmap[7].size(); ++i) PDFcol2loc[i] = 0.0;
+  
+  double PDFmrefloc[ pdfmap[8].size() ];
+  for (int i=0; i<pdfmap[8].size(); ++i) PDFmrefloc[i] = 0.0;
+
+
   // Decide if the uncertainties on the rest-frame colors should be analysed
   bool colAnalysis;
   colAnalysis = ((fltColRF[0]>=0) && (fltColRF[1]>=0) && (fltColRF[2]>=0) && (fltColRF[3]>=0) && (fltREF>=0));
@@ -1010,7 +1030,8 @@ void onesource::generatePDF(vector<SED*> &fulllib, const vector<size_t> &va, con
 void onesource::generatePDF_IR(vector<SED*>& fulllib){
 
   //4:["LIR"] 
-  double PDFlirloc[pdfmap[4].size()]={0.};
+  double PDFlirloc[pdfmap[4].size()];
+  for (int i = 0; i < pdfmap[4].size(); ++i) PDFlirloc[i] = 0.0;
 
   // parrallellize over each SED
   #ifdef _OPENMP

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -120,7 +120,7 @@ public:
     }
     else {
       // find the smallest interval in the grid provided by the user
-      vector<double> diff(gridz.size(),1.d);
+      vector<double> diff(gridz.size(),1.0);
       adjacent_difference(gridz.begin(), gridz.end(), diff.begin());
       zgmax = gridz.back();
       //the first and last element of adjacent_diff need to be removed from this difference


### PR DESCRIPTION
Make the minimal set of changes so that the code compiles on an M1 laptop using Apple's clang compiler. This involves:
- Removing the double suffix `d`
- Removing the array initialization from the dynamic arrays
- Removing the `loop-unroll-and-jam` flag.


