### PR TITLE
Commenting out pre-commit hooks that are not currently required

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,22 +9,23 @@ repos:
         name: Check template version
         description: Compare current template version against latest
         verbose: true
-    # Clear output from jupyter notebooks so that only the input cells are committed.
+    # Run clang-format to apply style rules to c++ code
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.1
     hooks:
     - id: clang-format
       name: clang-format
       types_or: [c++, c]
-  - repo: local
-    hooks:
-      - id: jupyter-nb-clear-output
-        name: Clear output from Jupyter notebooks
-        description: Clear output from Jupyter notebooks.
-        files: \.ipynb$
-        stages: [commit]
-        language: system
-        entry: jupyter nbconvert --clear-output
+    # Clear output from jupyter notebooks so that only the input cells are committed.
+  # - repo: local
+  #   hooks:
+  #     - id: jupyter-nb-clear-output
+  #       name: Clear output from Jupyter notebooks
+  #       description: Clear output from Jupyter notebooks.
+  #       files: \.ipynb$
+  #       stages: [commit]
+  #       language: system
+  #       entry: jupyter nbconvert --clear-output
     # Prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -68,39 +69,39 @@ repos:
     # notebooks from the docs, so users don't have to wait through the execution 
     # of each notebook or each commit. By default, these will be checked in the 
     # GitHub workflows.
-  - repo: local
-    hooks:
-      - id: sphinx-build
-        name: Build documentation with Sphinx
-        entry: sphinx-build
-        language: system
-        always_run: true
-        exclude_types: [file, symlink]
-        args:
-          [
-            "-M", # Run sphinx in make mode, so we can use -D flag later
-                  # Note: -M requires next 3 args to be builder, source, output
-            "html", # Specify builder
-            "./docs", # Source directory of documents
-            "./_readthedocs", # Output directory for rendered documents
-            "-T", # Show full trace back on exception
-            "-E", # Don't use saved env; always read all files
-            "-d", # Flag for cached environment and doctrees
-            "./docs/_build/doctrees", # Directory
-            "-D", # Flag to override settings in conf.py
-            "exclude_patterns=notebooks/*", # Exclude our notebooks from pre-commit
-          ]
+  # - repo: local
+  #   hooks:
+  #     - id: sphinx-build
+  #       name: Build documentation with Sphinx
+  #       entry: sphinx-build
+  #       language: system
+  #       always_run: true
+  #       exclude_types: [file, symlink]
+  #       args:
+  #         [
+  #           "-M", # Run sphinx in make mode, so we can use -D flag later
+  #                 # Note: -M requires next 3 args to be builder, source, output
+  #           "html", # Specify builder
+  #           "./docs", # Source directory of documents
+  #           "./_readthedocs", # Output directory for rendered documents
+  #           "-T", # Show full trace back on exception
+  #           "-E", # Don't use saved env; always read all files
+  #           "-d", # Flag for cached environment and doctrees
+  #           "./docs/_build/doctrees", # Directory
+  #           "-D", # Flag to override settings in conf.py
+  #           "exclude_patterns=notebooks/*", # Exclude our notebooks from pre-commit
+  #         ]
     # Run unit tests, verify that they pass. Note that coverage is run against
     # the ./src directory here because that is what will be committed. In the
     # github workflow script, the coverage is run against the installed package
     # and uploaded to Codecov by calling pytest like so:
     # `python -m pytest --cov=<package_name> --cov-report=xml`
-  - repo: local
-    hooks:
-      - id: pytest-check
-        name: Run unit tests
-        description: Run unit tests with pytest.
-        entry: bash -c "if python -m pytest --co -qq; then python -m pytest --cov=./src --cov-report=html; fi"
-        language: system
-        pass_filenames: false
-        always_run: true
+  # - repo: local
+  #   hooks:
+  #     - id: pytest-check
+  #       name: Run unit tests
+  #       description: Run unit tests with pytest.
+  #       entry: bash -c "if python -m pytest --co -qq; then python -m pytest --cov=./src --cov-report=html; fi"
+  #       language: system
+  #       pass_filenames: false
+  #       always_run: true


### PR DESCRIPTION
I chose not to remove them entirely because we'll want to bring them back shortly as we continue to move code over from the gitlab repo to the github repo. 