### PR TITLE
Create github action to build c++ code

### DIFF
--- a/.github/workflows/compile-cpp.yml
+++ b/.github/workflows/compile-cpp.yml
@@ -18,11 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Update gcc
-      if : matrix.os == 'macos-14'
-      run: |
-        brew install gcc
-        brew link --overwrite gcc
+    - uses: maxim-lobanov/setup-xcode@v1
+      if: matrix.os == 'macos-14'
+      with:
+        xcode-version: '15.1'
 
     - name: make
       run: |


### PR DESCRIPTION
Create compile-cpp.yml which will attempt to run `make` to compile the c code on ubuntu and 2 different types of mac hardware (intel and M1). 

I'm not currently attempting to build for windows, but we can add that if there's a large user base with that hardware.

