### PR TITLE
Indicate to RTD that it should clone pybind11.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,3 +20,7 @@ python:
    - requirements: docs/requirements.txt
    - method: pip
      path: .
+
+submodules:
+   include: all
+   recursive: true


### PR DESCRIPTION
Readthedocs build is currently failing because it can't find pybind11. We need to include it in the list of submodules that are cloned when RTD attempts to build. 