### PR TITLE
Adding limited retry logic when expected files are not found.

### DIFF
--- a/src/lephare/data_retrieval.py
+++ b/src/lephare/data_retrieval.py
@@ -23,6 +23,8 @@ DEFAULT_REGISTRY_FILE = "data_registry.txt"
 #  default cache location and return its path
 DEFAULT_LOCAL_DATA_PATH = "./data"
 
+# If a file is not downloaded the first time, retry this many times
+MAX_RETRY_ATTEMPTS = 2
 
 __all__ = [
     "download_all_files",
@@ -229,7 +231,7 @@ def download_file(retriever, file_name, ignore_registry=False):
         return retriever.fetch(file_name)
 
 
-def download_all_files(retriever, file_names, ignore_registry=False, retry=2):
+def download_all_files(retriever, file_names, ignore_registry=False, retry=MAX_RETRY_ATTEMPTS):
     """Download all files in the given list using the retriever.
 
     Parameters
@@ -240,6 +242,8 @@ def download_all_files(retriever, file_names, ignore_registry=False, retry=2):
         List of file names to download.
     ignore_registry : bool
         If True, download the files without checking their hashes against the registry.
+    retry : int
+        Number of times to retry downloading a file if first attempt fails.
 
     Returns
     -------

--- a/src/lephare/data_retrieval.py
+++ b/src/lephare/data_retrieval.py
@@ -229,7 +229,7 @@ def download_file(retriever, file_name, ignore_registry=False):
         return retriever.fetch(file_name)
 
 
-def download_all_files(retriever, file_names, ignore_registry=False):
+def download_all_files(retriever, file_names, ignore_registry=False, retry=2):
     """Download all files in the given list using the retriever.
 
     Parameters
@@ -270,7 +270,12 @@ def download_all_files(retriever, file_names, ignore_registry=False):
 
     # Finish with some checks on our downloaded files
     absolute_file_names = [os.path.join(retriever.path, file_name) for file_name in file_names]
-    _check_downloaded_files(absolute_file_names, completed_futures)
+    all_files_present = _check_downloaded_files(absolute_file_names, completed_futures)
+
+    if not all_files_present and retry > 0:
+        print("Retrying download for missing files...")
+        download_all_files(retriever, file_names, ignore_registry=ignore_registry, retry=retry - 1)
+
 
 
 def _check_downloaded_files(file_names, completed_futures):


### PR DESCRIPTION
After @raphaelshirley got the documentation notebooks building on github, I noticed a couple of odd failures to build in ReadTheDocs.

I tried running the notebook locally and discovered that indeed one file wasn't downloaded, but that retrying the download would successfully retrieve the file. My guess is that there is some transient issue that will randomly prevent some file from being fetched successfully. 

I've added trivial retry logic to the `download_all_files` function that will attempt to download missing files at most 3 times. I also tried using the `retry_if_failed` setting for `pooch.create` but that didn't seem to work. To be clear, I'm not sure if this is the best solution, but it seems to work. @OliviaLynn I would love your input on this, especially since you have a better understanding of the way the threadpool is working - if there's a smarter way of doing this, I'm all ears :) 

I tested by rerunning the file retrieval cell in the `Building_list_of_onesources` notebook repeatedly (deleting the cache directory in between each run) until I finally hit on an instance where a couple of files were not downloaded. The relevant snippet of output is copied below:

```
Checking/downloading 427 files...
Downloading file 'opa/tau20.out' from 'https://raw.githubusercontent.com/lephare-photoz/lephare-data/main/opa/tau20.out' to '/home/drew/.cache/lephare/data'.
Downloading file 'opa/tau21.out' from 'https://raw.githubusercontent.com/lephare-photoz/lephare-data/main/opa/tau21.out' to '/home/drew/.cache/lephare/data'.
...
Future completed with an exception: HTTPSConnectionPool(host='raw.githubusercontent.com', port=443): Read timed out. (read timeout=5)
Future completed with an exception: HTTPSConnectionPool(host='raw.githubusercontent.com', port=443): Read timed out. (read timeout=5)
Downloading file 'sed/STAR/PICKLES/o5v.sed.ext' from 'https://raw.githubusercontent.com/lephare-photoz/lephare-data/main/sed/STAR/PICKLES/o5v.sed.ext' to '/home/drew/.cache/lephare/data'.
Downloading file 'sed/STAR/BD/lte33-4.5-0.0.NextGen.7.sed' from 'https://raw.githubusercontent.com/lephare-photoz/lephare-data/main/sed/STAR/BD/lte33-4.5-0.0.NextGen.7.sed' to '/home/drew/.cache/lephare/data'.
Downloading file 'sed/STAR/BD/lte80-4.5-0.0.NextGen.7.sed' from 'https://raw.githubusercontent.com/lephare-photoz/lephare-data/main/sed/STAR/BD/lte80-4.5-0.0.NextGen.7.sed' to '/home/drew/.cache/lephare/data'.
424 completed.
The following file was not downloaded: /home/drew/.cache/lephare/data/sed/STAR/PICKLES/o5v.sed.ext
The following file was not downloaded: /home/drew/.cache/lephare/data/sed/STAR/BD/lte80-4.5-0.0.NextGen.7.sed
The following file was not downloaded: /home/drew/.cache/lephare/data/sed/STAR/BD/lte33-4.5-0.0.NextGen.7.sed
Retrying download for missing files...
Checking/downloading 427 files...
Downloading data from 'https://raw.githubusercontent.com/lephare-photoz/lephare-data/main/alloutputkeys.txt' to file '/home/drew/.cache/lephare/data/alloutputkeys.txt'.
427 completed.
All files downloaded successfully and are non-empty.
Downloading without registry: alloutputkeys.txt...
SHA256 hash of downloaded file: bfb021b6750479edec7d258e213d3a9959c96a4ee4800687b43df93697d8a3e6
Use this value as the 'known_hash' argument of 'pooch.retrieve' to ensure that the file hasn't changed if it is downloaded again in the future.
Downloading file 'examples/COSMOS.in' from 'https://raw.githubusercontent.com/lephare-photoz/lephare-data/main/examples/COSMOS.in' to '/home/drew/.cache/lephare/data'.
Checking/downloading 1 files...
1 completed.
All files downloaded successfully and are non-empty.
```

Though the output lines are bit jumbled together, of the initial 427 files to download, 424 were successfully downloaded on the first try, and three were missing. Thus a second attempt was made, during which the 3 missing files were successfully downloaded. 
