### PR TITLE
Try to speed up example notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     # This hook should always pass. It will print a message if the local version 
     # is out of date.
   - repo: https://github.com/lincc-frameworks/pre-commit-hooks
-    rev: v0.1.1
+    rev: v0.1.2
     hooks:
       - id: check-lincc-frameworks-template-version
         name: Check template version
@@ -11,7 +11,7 @@ repos:
         verbose: true
     # Run clang-format to apply style rules to c++ code
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.1
+    rev: v18.1.3
     hooks:
     - id: clang-format
       name: clang-format
@@ -28,7 +28,7 @@ repos:
         entry: jupyter nbconvert --clear-output
     # Prevents committing directly branches named 'main' and 'master'.
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: no-commit-to-branch
         name: Prevent main branch commits
@@ -39,20 +39,20 @@ repos:
         args: ['--maxkb=500']
     # Verify that pyproject.toml is well formed
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.1
+    rev: v0.16
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
         description: Verify that pyproject.toml adheres to the established schema.
     # Verify that GitHub workflows are well formed
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.0
+    rev: 0.28.2
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.1
+    rev: v0.3.7
     hooks:
       - id: ruff
         name: Lint code using ruff; sort and organize imports 
@@ -60,7 +60,7 @@ repos:
         args: ["--fix"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.1
+    rev: v0.3.7
     hooks:
       - id: ruff-format
         name: Format code using ruff

--- a/docs/notebooks/Building_list_of_onesources.ipynb
+++ b/docs/notebooks/Building_list_of_onesources.ipynb
@@ -62,7 +62,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#before running PhotoZ we must run sedtolib and maggal\n",
+    "#before running PhotoZ we must run filt, sedtolib and maggal\n",
+    "filterLib = lp.Filter(config_file=config_file)\n",
+    "filterLib.run()\n",
     "sedlib = lp.Sedtolib(config_keymap=keymap)\n",
     "sedlib.run(typ=\"STAR\", star_sed=\"$LEPHAREDIR/sed/STAR/STAR_MOD_ALL.list\")\n",
     "sedlib.run(typ=\"QSO\", qso_sed=\"$LEPHAREDIR/sed/QSO/SALVATO09/AGN_MOD.list\", gal_lib=\"LIB_QSO\")\n",
@@ -256,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "photz.run_photoz(photozlist[:100], a0, a1)"
+    "photz.run_photoz(photozlist[:10], a0, a1)"
    ]
   },
   {
@@ -266,7 +268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t = photz.build_output_tables(photozlist[:100], para_out=\"./data/output.para\", filename=\"toto.fits\")"
+    "t = photz.build_output_tables(photozlist[:10], para_out=\"./data/output.para\", filename=\"toto.fits\")"
    ]
   },
   {

--- a/docs/notebooks/Example_full_run.ipynb
+++ b/docs/notebooks/Example_full_run.ipynb
@@ -53,7 +53,9 @@
     "config_file = \"./data/COSMOS.para\"\n",
     "keymap = lp.read_config(config_file)\n",
     "#Get the auxiliary files required.\n",
-    "lp.data_retrieval.get_auxiliary_data(keymap=keymap,additional_files=[\"examples/COSMOS.in\"])"
+    "lp.data_retrieval.get_auxiliary_data(\n",
+    "    keymap=keymap,\n",
+    "    additional_files=[\"examples/COSMOS.in\",\"examples/config.yml\",\"examples/output.para\"])"
    ]
   },
   {
@@ -464,7 +466,7 @@
    "outputs": [],
    "source": [
     "photozlist = []\n",
-    "for i in range(100):\n",
+    "for i in range(10):\n",
     "    oneObj = lp.onesource(i, photz.gridz)\n",
     "    oneObj.readsource(str(id[i]), fluxes[i, :], efluxes[i, :], int(context[i]), zspec[i], \" \")\n",
     "    photz.prep_data(oneObj)\n",
@@ -487,7 +489,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "photz.run_photoz(photozlist[:100], a0, a1)\n",
+    "photz.run_photoz(photozlist[:10], a0, a1)\n",
     "# If adaption of the zero-points is turned off\n",
     "# photz.run_photoz(photozlist[:100], [],[] )"
    ]
@@ -507,7 +509,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t = photz.build_output_tables(photozlist[:100], para_out=None, filename=\"outputpython.fits\")"
+    "t = photz.build_output_tables(photozlist[:10], para_out=None, filename=\"outputpython.fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a47dedd-414c-4bfd-ae20-de3b4021badf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t[:5]"
    ]
   },
   {
@@ -527,7 +539,7 @@
    "source": [
     "import time\n",
     "\n",
-    "photz.write_outputs(photozlist[:100], int(time.time()))"
+    "photz.write_outputs(photozlist[:10], int(time.time()))"
    ]
   },
   {

--- a/docs/notebooks/Example_full_run.ipynb
+++ b/docs/notebooks/Example_full_run.ipynb
@@ -525,7 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a47dedd-414c-4bfd-ae20-de3b4021badf",
+   "id": "d7e7c675",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/notebooks/data/COSMOS.para
+++ b/docs/notebooks/data/COSMOS.para
@@ -61,7 +61,7 @@ GAL_LIB_OUT	CE_COSMOS	# Output GALAXY LIBRARY  (-> $ZPHOTWORK/lib_mag/*)
 #------------------   MAG + Z_STEP + COSMO + EXTINCTION   -----------------------------
 MAGTYPE         AB		# Magnitude type (AB or VEGA)
 ZGRID_TYPE      0               # Define the kind of redshift grid (0: linear ; 1: dz*(1+z)) 
-Z_STEP 		0.01,0.,7. 	# dz, zmin, zmax 
+Z_STEP 		0.1,0.,5. 	# dz, zmin, zmax VERY SPARSE FOR EXAMPLE ONLY
 COSMOLOGY	70,0.3,0.7	# H0,om0,lbd0    (if lb0>0->om0+lbd0=1)
 MOD_EXTINC 	0,0		# model range for extinction 
 EXTINC_LAW	SMC_prevot.dat,SB_calzetti.dat,SB_calzetti_bump1.dat,SB_calzetti_bump2.dat	# ext. law (in  $ZPHOTDIR/ext/*)


### PR DESCRIPTION
Requirement to rerun sedtolib and maggal might be main cause. Perhaps we can reduced zgrids to speeds these up

Closes 83

these still may be quite slow. Perhaps we can increase the speed of the sedtolib and maggal stages by making the example zgrids less fine grained. Given these are just examples can we reduce the grids by a factor 10 and add a note to suers that they should increase it for actual runs.