### PR TITLE
Fix circular imports, update pytest fixtures

### DIFF
--- a/src/lephare/filterSvc.py
+++ b/src/lephare/filterSvc.py
@@ -6,8 +6,8 @@ import xml.dom.minidom
 import requests
 import yaml
 
-from lephare import LEPHAREDIR #ADD
-from lephare._lephare import flt, check_first_char
+from lephare import LEPHAREDIR  # ADD
+from lephare._lephare import check_first_char, flt
 
 __all__ = [
     "FilterSvc",

--- a/src/lephare/filterSvc.py
+++ b/src/lephare/filterSvc.py
@@ -6,7 +6,8 @@ import xml.dom.minidom
 import requests
 import yaml
 
-from . import LEPHAREDIR, check_first_char, flt
+from lephare import LEPHAREDIR #ADD
+from lephare._lephare import flt, check_first_char
 
 __all__ = [
     "FilterSvc",

--- a/src/lephare/filterSvc.py
+++ b/src/lephare/filterSvc.py
@@ -6,7 +6,7 @@ import xml.dom.minidom
 import requests
 import yaml
 
-from lephare import LEPHAREDIR  # ADD
+from lephare import LEPHAREDIR
 from lephare._lephare import check_first_char, flt
 
 __all__ = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 # Set "LEPHAREDIR" locally for tests if it is not already set.
 if "LEPHAREDIR" not in os.environ:
     test_dir = os.path.abspath(os.path.dirname(__file__))
-    os.environ["LEPHAREDIR"] = os.path.join(test_dir, "..")
+    os.environ["LEPHAREDIR"] = os.path.join(test_dir, "data")
 
 # Set "LEPHAREWORK" locally for tests if it is not already set.
 if "LEPHAREWORK" not in os.environ:

--- a/tests/lephare/test_filter.py
+++ b/tests/lephare/test_filter.py
@@ -2,16 +2,16 @@ import os
 
 import numpy as np
 import pytest
-
-from lephare import flt  # noqa: E402
+from lephare import (
+    flt,  # noqa: E402
+)
 from lephare.filterSvc import FilterSvc  # noqa: E402
 
-
-from lephare import LEPHAREDIR
 
 @pytest.fixture
 def filter_file(test_data_dir):
     return os.path.join(test_data_dir, "filt/subaru/IB527.pb")
+
 
 def test_flt_class(filter_file):
     tophat = flt(100.0, 200.0, 50)

--- a/tests/lephare/test_filter.py
+++ b/tests/lephare/test_filter.py
@@ -3,17 +3,17 @@ import os
 import numpy as np
 import pytest
 
-test_dir = os.path.abspath(os.path.dirname(__file__))
-test_data_dir = os.path.join(test_dir, "../data")
-os.environ["LEPHAREDIR"] = test_data_dir
-
 from lephare import flt  # noqa: E402
 from lephare.filterSvc import FilterSvc  # noqa: E402
 
-filter_file = os.path.join(test_data_dir, "filt/subaru/IB527.pb")
 
+from lephare import LEPHAREDIR
 
-def test_flt_class():
+@pytest.fixture
+def filter_file(test_data_dir):
+    return os.path.join(test_data_dir, "filt/subaru/IB527.pb")
+
+def test_flt_class(filter_file):
     tophat = flt(100.0, 200.0, 50)
     assert tophat.name == ""
     # this is wrong but an effect of improper C++ code
@@ -24,7 +24,7 @@ def test_flt_class():
     assert f.lambdaMean() == pytest.approx(5262.2831, 1.0e-4)
 
 
-def test_filtersvc():
+def test_filtersvc(test_data_dir, filter_file):
     f = FilterSvc.from_file(filter_file, trans=1, calib=0)
     assert f.width() == pytest.approx(241.9479, 1.0e-4)
     assert f.lambdaMean() == pytest.approx(5262.2831, 1.0e-4)


### PR DESCRIPTION
Fixing unit tests failing (as in https://github.com/lephare-photoz/lephare/actions/runs/8738664566).

This came down to some circular imports and an outdated path to test data (which are now bundled up in pytest fixtures).