### PR TITLE
Check registry file hash before downloading

### DIFF
--- a/src/lephare/data_retrieval.py
+++ b/src/lephare/data_retrieval.py
@@ -116,7 +116,7 @@ def download_registry_from_github(url="", outfile=""):
 
     # If local registry hash matches remote hash, our registry is already up-to-date:
     if os.path.isfile(outfile) and _check_registry_is_latest_version(url, outfile):
-        print(f"Local registry file is up to date: {local_registry_file}")
+        print(f"Local registry file is up to date: {outfile}")
         return
 
     # Download the registry file

--- a/src/lephare/data_retrieval.py
+++ b/src/lephare/data_retrieval.py
@@ -89,23 +89,22 @@ def download_registry_from_github(url="", outfile=""):
         local_registry_hash = pooch.file_hash(outfile, alg="sha256")
         registry_hash_url = os.path.splitext(url)[0] + "_hash.sha256"
         try:
-            response = requests.get(registry_hash_url, timeout=60)
-            if response.status_code == 200:
-                remote_registry_hash = response.text.strip()
-                if local_registry_hash == remote_registry_hash:
-                    print(f"Local registry file is up to date: {outfile}")
-                    return
+            hash_response = requests.get(registry_hash_url, timeout=60)
+            if hash_response.status_code == 200 and hash_response.text.strip() == local_registry_hash:
+                print(f"Local registry file is up to date: {outfile}")
+                return
         except requests.exceptions.RequestException as e:
             print(f"Failed to fetch registry hash file: {e}")
 
     # Download the registry file
-    response = requests.get(url, timeout=60)
-    if response.status_code == 200:
+    registry_response = requests.get(url, timeout=60)
+    if registry_response.status_code == 200:
         with open(outfile, "w", encoding="utf-8") as file:
-            file.write(response.text)
+            file.write(registry_response.text)
         print(f"Registry file downloaded and saved as {outfile}.")
+        return
     else:
-        raise requests.exceptions.HTTPError(f"Failed to fetch file: {response.status_code}")
+        raise requests.exceptions.HTTPError(f"Failed to fetch file: {registry_response.status_code}")
 
 
 def read_list_file(list_file, prefix=""):

--- a/src/lephare/data_retrieval.py
+++ b/src/lephare/data_retrieval.py
@@ -83,11 +83,11 @@ def download_registry_from_github(url="", outfile=""):
     if outfile == "":
         outfile = DEFAULT_REGISTRY_FILE
 
-    # Try to download the registry hash file, to see if we can skip downloading 
+    # Try to download the registry hash file, to see if we can skip downloading
     # the actual registry file
-    if os.file_exists(outfile):
+    if os.path.isfile(outfile):
         local_registry_hash = pooch.file_hash(outfile, alg="sha256")
-        registry_hash_url = os.splitext(url)[0] + "_hash.sha256"
+        registry_hash_url = os.path.splitext(url)[0] + "_hash.sha256"
         try:
             response = requests.get(registry_hash_url, timeout=60)
             if response.status_code == 200:

--- a/src/lephare/data_retrieval.py
+++ b/src/lephare/data_retrieval.py
@@ -86,12 +86,7 @@ def _check_registry_is_latest_version(remote_registry_url, local_registry_file):
     remote_hash_response = requests.get(remote_hash_url, timeout=60)
     remote_hash_response.raise_for_status()  # Raise exceptions for non-200 status codes
 
-    if remote_hash_response.text.strip() == local_registry_hash:
-        print(f"Local registry file is up to date: {local_registry_file}")
-        return True
-    else:
-        print(f"Local registry file is not up to date: {local_registry_file}")
-        return False
+    return remote_hash_response.text.strip() == local_registry_hash
 
 
 def download_registry_from_github(url="", outfile=""):
@@ -121,6 +116,7 @@ def download_registry_from_github(url="", outfile=""):
 
     # If local registry hash matches remote hash, our registry is already up-to-date:
     if os.path.isfile(outfile) and _check_registry_is_latest_version(url, outfile):
+        print(f"Local registry file is up to date: {local_registry_file}")
         return
 
     # Download the registry file

--- a/tests/lephare/test_data_retrieval.py
+++ b/tests/lephare/test_data_retrieval.py
@@ -40,6 +40,23 @@ def test_download_registry_from_github_success(mock_get):
             assert file.read() == "file1\nfile2\nfile3"
 
 
+@patch("os.path.isfile")
+@patch("pooch.file_hash")
+@patch("requests.get")
+def test_download_registry_hash_already_matches(mock_get, mock_file_hash, mock_isfile):
+    mock_isfile.return_value = True
+    mock_file_hash.return_value = "registryhash123"
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = "registryhash123"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outfile = os.path.join(tmpdir, "registry.txt")
+        download_registry_from_github(url="http://example.com/data_registry.txt", outfile=outfile)
+
+        assert mock_get.call_count == 1
+        assert mock_get.call_args[0][0] == "http://example.com/data_registry_hash.sha256"
+
+
 @patch("requests.get")
 def test_download_registry_from_github_failure(mock_get):
     mock_get.return_value.status_code = 404

--- a/tests/lephare/test_data_retrieval.py
+++ b/tests/lephare/test_data_retrieval.py
@@ -1,10 +1,8 @@
 import os
-import tempfile
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import pytest
-import requests
 from lephare.data_retrieval import (
     DEFAULT_BASE_DATA_URL,
     DEFAULT_LOCAL_DATA_PATH,
@@ -13,7 +11,6 @@ from lephare.data_retrieval import (
     _create_directories_from_files,
     download_all_files,
     download_file,
-    download_registry_from_github,
     filter_files_by_prefix,
     make_default_retriever,
     make_retriever,
@@ -26,70 +23,6 @@ def test_filter_file_by_prefix(test_data_dir):
     target_prefixes = ["prefix1", "prefix2"]
     expected_lines = ["prefix1_file1", "prefix2_file2"]
     assert filter_files_by_prefix(file_path, target_prefixes) == expected_lines
-
-
-@patch("requests.get")
-def test_download_registry_from_github_success(mock_get):
-    """Case: there's no local registry file, so we must download one."""
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.text = "file1\nfile2\nfile3"
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        download_registry_from_github(outfile=os.path.join(tmpdir, "registry.txt"))
-
-        with open(os.path.join(tmpdir, "registry.txt"), "r") as file:
-            assert file.read() == "file1\nfile2\nfile3"
-
-
-@patch("os.path.isfile")
-@patch("pooch.file_hash")
-@patch("requests.get")
-def test_download_registry_hash_already_matches(mock_get, mock_file_hash, mock_isfile):
-    """Case: we have a local registry file whose hash matches the remote hash."""
-    mock_isfile.return_value = True
-    mock_file_hash.return_value = "registryhash123"
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.text = "registryhash123"
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        outfile = os.path.join(tmpdir, "registry.txt")
-        download_registry_from_github(url="http://example.com/data_registry.txt", outfile=outfile)
-
-        assert mock_get.call_count == 1
-        assert mock_get.call_args[0][0] == "http://example.com/data_registry_hash.sha256"
-
-
-@patch("os.path.isfile")
-@patch("pooch.file_hash")
-@patch("requests.get")
-def test_download_registry_no_matching_hash(mock_get, mock_file_hash, mock_isfile):
-    """Case: we mock the existence of a local registry file, but its hash does
-    not match the hash of the remote registry file, so we must redownload the
-    registry file."""
-    mock_isfile.return_value = True
-    mock_file_hash.return_value = "registryhash123"
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.text = "hash_doesn't_match123"
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        outfile = os.path.join(tmpdir, "registry.txt")
-        download_registry_from_github(url="http://example.com/data_registry.txt", outfile=outfile)
-
-        # One call to download the hash file, one call to download the full registry file:
-        assert mock_get.call_count == 2
-        # The following set of [0][0][0] and such is because the call args list is
-        #     [call('http://example.com/data_registry_hash.sha256', timeout=60),
-        #      call('http://example.com/data_registry.txt', timeout=60)]
-        # and we're only interested in checking the urls:
-        assert mock_get.call_args_list[0][0][0] == "http://example.com/data_registry_hash.sha256"
-        assert mock_get.call_args_list[1][0][0] == "http://example.com/data_registry.txt"
-
-
-@patch("requests.get")
-def test_download_registry_from_github_failure(mock_get):
-    mock_get.return_value.status_code = 404
-    with pytest.raises(requests.exceptions.HTTPError):
-        download_registry_from_github()
 
 
 def test_read_list_file(test_data_dir):

--- a/tests/lephare/test_data_retrieval_registry.py
+++ b/tests/lephare/test_data_retrieval_registry.py
@@ -1,0 +1,109 @@
+"""There's a lot of branching logic in download_registry_from_github.
+
+I did my best to keep it simple, but it's still a little tricky.
+
+Here's how it works:
+
+Call download_registry_from_github
+1. Local registry file does not exist → Download remote registry file
+    1. Successfully downloaded registry file → Exit (now have local registry)
+    2. Fail to download registry file → raise Exception
+2. Local registry file exists
+    → Need to check if local registry is up to date
+    → Call _check_registry_is_latest_version
+        1. True → Exit (confirmed local registry is up to date)
+        2. False → Download updated version
+            1. Successfully downloaded registry file → Exit (local registry updated)
+            2. Fail to download registry file → raise Exception
+        3. Failed to download hash file → raise Exception
+"""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+import requests
+from lephare.data_retrieval import (
+    download_registry_from_github,
+)
+
+
+@patch("requests.get")
+def test_download_registry_success(mock_get):
+    # 1. Local registry does not exist
+    #     1. Successfully downloaded registry file
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = "file1\nfile2\nfile3"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        download_registry_from_github(outfile=os.path.join(tmpdir, "registry.txt"))
+
+        with open(os.path.join(tmpdir, "registry.txt"), "r") as file:
+            assert file.read() == "file1\nfile2\nfile3"
+
+
+@patch("requests.get")
+def test_download_registry_failure(mock_get):
+    # 1. Local registry does not exist
+    #     2. Fail to download registry file
+    mock_get.return_value.status_code = 404
+    with pytest.raises(requests.exceptions.HTTPError):
+        download_registry_from_github()
+
+
+@patch("os.path.isfile")
+@patch("pooch.file_hash")
+@patch("requests.get")
+def test_update_registry_hash_matches(mock_get, mock_file_hash, mock_isfile):
+    # 2. Local registry exists
+    #     1. _check_registry_is_latest_version == True
+    mock_isfile.return_value = True
+    mock_file_hash.return_value = "registryhash123"
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = "registryhash123"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outfile = os.path.join(tmpdir, "registry.txt")
+        download_registry_from_github(url="http://example.com/data_registry.txt", outfile=outfile)
+
+        assert mock_get.call_count == 1
+        assert mock_get.call_args[0][0] == "http://example.com/data_registry_hash.sha256"
+
+
+@patch("os.path.isfile")
+@patch("pooch.file_hash")
+@patch("requests.get")
+def test_update_registry_hash_mismatches(mock_get, mock_file_hash, mock_isfile):
+    # 2. Local registry exists
+    #     2. _check_registry_is_latest_version == False
+    #       2. Successfully downloaded registry file
+    mock_isfile.return_value = True
+    mock_file_hash.return_value = "registryhash123"
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = "hash_doesn't_match123"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outfile = os.path.join(tmpdir, "registry.txt")
+        download_registry_from_github(url="http://example.com/data_registry.txt", outfile=outfile)
+
+        # One call to download the hash file, one call to download the full registry file:
+        assert mock_get.call_count == 2
+        # The following set of [0][0][0] and such is because the call args list is
+        #     [call('http://example.com/data_registry_hash.sha256', timeout=60),
+        #      call('http://example.com/data_registry.txt', timeout=60)]
+        # and we're only interested in checking the urls:
+        assert mock_get.call_args_list[0][0][0] == "http://example.com/data_registry_hash.sha256"
+        assert mock_get.call_args_list[1][0][0] == "http://example.com/data_registry.txt"
+
+
+@patch("os.path.isfile")
+@patch("requests.get")
+def test_update_registry_hash_mismatches_and_download_fails(mock_get, mock_isfile):
+    # 2. Local registry exists
+    #     2. _check_registry_is_latest_version == False
+    #       2. Fail to download registry file
+    mock_isfile.return_value = True
+    mock_get.return_value.status_code = 404
+    with pytest.raises(requests.exceptions.HTTPError):
+        download_registry_from_github()

--- a/tests/lephare/test_data_retrieval_registry.py
+++ b/tests/lephare/test_data_retrieval_registry.py
@@ -77,7 +77,7 @@ def test_update_registry_hash_matches(mock_get, mock_file_hash, mock_isfile):
 def test_update_registry_hash_mismatches(mock_get, mock_file_hash, mock_isfile):
     # 2. Local registry exists
     #     2. _check_registry_is_latest_version == False
-    #       2. Successfully downloaded registry file
+    #         1. Successfully downloaded registry file
     mock_isfile.return_value = True
     mock_file_hash.return_value = "registryhash123"
     mock_get.return_value.status_code = 200
@@ -103,7 +103,7 @@ def test_update_registry_hash_mismatches(mock_get, mock_file_hash, mock_isfile):
 def test_update_registry_hash_mismatches_and_download_fails(mock_get, mock_file_hash, mock_isfile):
     # 2. Local registry exists
     #     2. _check_registry_is_latest_version == False
-    #       2. Fail to download registry file
+    #         2. Fail to download registry file
     mock_isfile.return_value = True
     mock_file_hash.return_value = "registryhash123"
     mock_get.return_value.status_code = 200
@@ -111,4 +111,18 @@ def test_update_registry_hash_mismatches_and_download_fails(mock_get, mock_file_
 
     mock_get.return_value.status_code = 404
     with pytest.raises(requests.exceptions.HTTPError):
+        download_registry_from_github()
+
+
+@patch("os.path.isfile")
+@patch("pooch.file_hash")
+@patch("requests.get")
+def test_update_registry_hash_download_fails(mock_get, mock_file_hash, mock_isfile):
+    # 2. Local registry exists
+    #     3. Fail to download registry hash file
+    mock_isfile.return_value = True
+    mock_file_hash.return_value = "registryhash123"
+
+    mock_get.return_value.status_code = 404
+    with pytest.raises(requests.exceptions.RequestException):
         download_registry_from_github()

--- a/tests/lephare/test_data_retrieval_registry.py
+++ b/tests/lephare/test_data_retrieval_registry.py
@@ -20,7 +20,7 @@ Call download_registry_from_github
 
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import requests
@@ -29,100 +29,153 @@ from lephare.data_retrieval import (
 )
 
 
-@patch("requests.get")
-def test_download_registry_success(mock_get):
-    # 1. Local registry does not exist
+def test_download_registry_success():
+    # 1. Local registry does not exist (so no mocking needed here)
     #     1. Successfully downloaded registry file
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.text = "file1\nfile2\nfile3"
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        download_registry_from_github(outfile=os.path.join(tmpdir, "registry.txt"))
+    # Mock remote registry file
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = "file1\nfile2\nfile3"
+    with patch("requests.get", return_value=mock_response) as mock_get_remote_registry:  # noqa: F841
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            registry_outfile = os.path.join(tmp_dir, "registry.txt")
+            download_registry_from_github(outfile=registry_outfile)
+            # Check that we can open it (and it contains expected content)
+            with open(registry_outfile, "r") as file:
+                assert file.read() == "file1\nfile2\nfile3"
 
-        with open(os.path.join(tmpdir, "registry.txt"), "r") as file:
-            assert file.read() == "file1\nfile2\nfile3"
 
-
-@patch("requests.get")
-def test_download_registry_failure(mock_get):
-    # 1. Local registry does not exist
+def test_download_registry_failure():
+    # 1. Local registry does not exist (no mocking needed)
     #     2. Fail to download registry file
-    mock_get.return_value.status_code = 404
-    with pytest.raises(requests.exceptions.HTTPError):
-        download_registry_from_github()
+
+    # Mock failed registry file download
+    mock_response = Mock()
+    mock_response.status_code = 404
+    with patch("requests.get", return_value=mock_response) as mock_get_remote_registry:  # noqa: F841
+        with pytest.raises(requests.exceptions.HTTPError):
+            download_registry_from_github()
 
 
-@patch("os.path.isfile")
-@patch("pooch.file_hash")
-@patch("requests.get")
-def test_update_registry_hash_matches(mock_get, mock_file_hash, mock_isfile):
+def test_update_registry_hash_matches():
     # 2. Local registry exists
     #     1. _check_registry_is_latest_version == True
-    mock_isfile.return_value = True
-    mock_file_hash.return_value = "registryhash123"
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.text = "registryhash123"
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        outfile = os.path.join(tmpdir, "registry.txt")
-        download_registry_from_github(url="http://example.com/data_registry.txt", outfile=outfile)
+    # Mock the local registry file existing
+    with patch("os.path.isfile", return_value=True) as mock_local_registry_existing:  # noqa: F841
+        # Mock local registry having a certain pooch hash
+        with patch("pooch.file_hash", return_value="registryhash123") as mock_local_registry_hash:  # noqa: F841
+            # Mock getting the remote registry hash file
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.text = "registryhash123"
+            with patch("requests.get", return_value=mock_response) as mock_get_remote_hash_file:
+                # Call the function
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    registry_outfile = os.path.join(tmp_dir, "registry.txt")
+                    download_registry_from_github(
+                        url="http://example.com/data_registry.txt", outfile=registry_outfile
+                    )
+                    # Assert that we only make 1 request for the hash file, and that we used the right url:
+                    assert mock_get_remote_hash_file.call_count == 1
+                    assert (
+                        mock_get_remote_hash_file.call_args[0][0]
+                        == "http://example.com/data_registry_hash.sha256"
+                    )
 
-        assert mock_get.call_count == 1
-        assert mock_get.call_args[0][0] == "http://example.com/data_registry_hash.sha256"
 
-
-@patch("os.path.isfile")
-@patch("pooch.file_hash")
-@patch("requests.get")
-def test_update_registry_hash_mismatches(mock_get, mock_file_hash, mock_isfile):
+def test_update_registry_hash_mismatches():
     # 2. Local registry exists
     #     2. _check_registry_is_latest_version == False
     #         1. Successfully downloaded registry file
-    mock_isfile.return_value = True
-    mock_file_hash.return_value = "registryhash123"
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.text = "hash_doesn't_match123"
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        outfile = os.path.join(tmpdir, "registry.txt")
-        download_registry_from_github(url="http://example.com/data_registry.txt", outfile=outfile)
+    # Mock the local registry file existing
+    with patch("os.path.isfile", return_value=True) as mock_local_registry_existing:  # noqa: F841
+        # Mock local registry having a certain pooch hash
+        with patch("pooch.file_hash", return_value="registryhash123") as mock_local_registry_hash:  # noqa: F841
+            # Mock getting the remote hash/registry files
+            mock_hash_response = Mock()
+            mock_hash_response.status_code = 200
+            mock_hash_response.text = "hash_doesn't_match123"
 
-        # One call to download the hash file, one call to download the full registry file:
-        assert mock_get.call_count == 2
-        # The following set of [0][0][0] and such is because the call args list is
-        #     [call('http://example.com/data_registry_hash.sha256', timeout=60),
-        #      call('http://example.com/data_registry.txt', timeout=60)]
-        # and we're only interested in checking the urls:
-        assert mock_get.call_args_list[0][0][0] == "http://example.com/data_registry_hash.sha256"
-        assert mock_get.call_args_list[1][0][0] == "http://example.com/data_registry.txt"
+            mock_registry_response = Mock()
+            mock_registry_response.status_code = 200
+            mock_registry_response.text = "file1\nfile2\nfile3"
+
+            def which_mock_get(*args, **kwargs):
+                url = args[0]
+                if "hash.sha256" in url:
+                    return mock_hash_response
+                else:
+                    return mock_registry_response
+
+            with patch("requests.get", side_effect=which_mock_get) as mock_remote_files_get:
+                # Call the function
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    registry_outfile = os.path.join(tmp_dir, "registry.txt")
+                    download_registry_from_github(
+                        url="http://example.com/data_registry.txt", outfile=registry_outfile
+                    )
+                    # Checks:
+                    # One call to download the hash file, one call to download the full registry file:
+                    assert mock_remote_files_get.call_count == 2
+                    # The following set of [0][0][0] and such is because the call args list is
+                    #     [call('http://example.com/data_registry_hash.sha256', timeout=60),
+                    #      call('http://example.com/data_registry.txt', timeout=60)]
+                    # and we're only interested in checking the urls:
+                    assert (
+                        mock_remote_files_get.call_args_list[0][0][0]
+                        == "http://example.com/data_registry_hash.sha256"
+                    )
+                    assert (
+                        mock_remote_files_get.call_args_list[1][0][0]
+                        == "http://example.com/data_registry.txt"
+                    )
 
 
-@patch("os.path.isfile")
-@patch("pooch.file_hash")
-@patch("requests.get")
-def test_update_registry_hash_mismatches_and_download_fails(mock_get, mock_file_hash, mock_isfile):
+def test_update_registry_hash_mismatches_and_download_fails():
     # 2. Local registry exists
     #     2. _check_registry_is_latest_version == False
     #         2. Fail to download registry file
-    mock_isfile.return_value = True
-    mock_file_hash.return_value = "registryhash123"
-    mock_get.return_value.status_code = 200
-    mock_get.return_value.text = "hash_doesn't_match123"
 
-    mock_get.return_value.status_code = 404
-    with pytest.raises(requests.exceptions.HTTPError):
-        download_registry_from_github()
+    # Mock the local registry file existing
+    with patch("os.path.isfile", return_value=True) as mock_local_registry_existing:  # noqa: F841
+        # Mock local registry having a certain pooch hash
+        with patch("pooch.file_hash", return_value="registryhash123") as mock_local_registry_hash:  # noqa: F841
+            # Mock getting the remote hash/registry files
+            mock_hash_response = Mock()
+            mock_hash_response.status_code = 200
+            mock_hash_response.text = "hash_doesn't_match123"
+
+            mock_registry_response = Mock()
+            mock_registry_response.status_code = 404
+
+            def which_mock_get(*args, **kwargs):
+                url = args[0]
+                if "hash.sha256" in url:
+                    return mock_hash_response
+                else:
+                    return mock_registry_response
+
+            with patch("requests.get", side_effect=which_mock_get) as mock_remote_files_get:  # noqa: F841
+                # Check that we raise HTTPError as expected
+                with pytest.raises(requests.exceptions.HTTPError):
+                    download_registry_from_github()
 
 
-@patch("os.path.isfile")
-@patch("pooch.file_hash")
-@patch("requests.get")
-def test_update_registry_hash_download_fails(mock_get, mock_file_hash, mock_isfile):
+def test_update_registry_hash_download_fails():
     # 2. Local registry exists
     #     3. Fail to download registry hash file
-    mock_isfile.return_value = True
-    mock_file_hash.return_value = "registryhash123"
 
-    mock_get.return_value.status_code = 404
-    with pytest.raises(requests.exceptions.RequestException):
-        download_registry_from_github()
+    # Mock the local registry file existing
+    with patch("os.path.isfile", return_value=True) as mock_local_registry_existing:  # noqa: F841
+        # Mock local registry having a certain pooch hash
+        with patch("pooch.file_hash", return_value="registryhash123") as mock_local_registry_hash:  # noqa: F841
+            # Mock getting the remote hash/registry files
+            mock_hash_response = Mock()
+            mock_hash_response.status_code = 404
+            with patch("requests.get", return_value=mock_hash_response) as mock_get_remote_hash_file:  # noqa: F841
+                # Check that we get the expected exception
+                with pytest.raises(requests.exceptions.RequestException):
+                    download_registry_from_github()

--- a/tests/lephare/test_data_retrieval_registry.py
+++ b/tests/lephare/test_data_retrieval_registry.py
@@ -98,13 +98,16 @@ def test_update_registry_hash_mismatches(mock_get, mock_file_hash, mock_isfile):
 
 
 @patch("os.path.isfile")
+@patch("pooch.file_hash")
 @patch("requests.get")
-def test_update_registry_hash_mismatches_and_download_fails(mock_get, mock_isfile):
+def test_update_registry_hash_mismatches_and_download_fails(mock_get, mock_file_hash, mock_isfile):
     # 2. Local registry exists
     #     2. _check_registry_is_latest_version == False
     #       2. Fail to download registry file
     mock_isfile.return_value = True
-    mock_get.return_value.text = "file1\nfile2\nfile3"
+    mock_file_hash.return_value = "registryhash123"
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.text = "hash_doesn't_match123"
 
     mock_get.return_value.status_code = 404
     with pytest.raises(requests.exceptions.HTTPError):

--- a/tests/lephare/test_data_retrieval_registry.py
+++ b/tests/lephare/test_data_retrieval_registry.py
@@ -104,6 +104,8 @@ def test_update_registry_hash_mismatches_and_download_fails(mock_get, mock_isfil
     #     2. _check_registry_is_latest_version == False
     #       2. Fail to download registry file
     mock_isfile.return_value = True
+    mock_get.return_value.text = "file1\nfile2\nfile3"
+
     mock_get.return_value.status_code = 404
     with pytest.raises(requests.exceptions.HTTPError):
         download_registry_from_github()

--- a/tests/lephare/test_data_retrieval_registry.py
+++ b/tests/lephare/test_data_retrieval_registry.py
@@ -52,7 +52,9 @@ def test_download_registry_failure():
 
     # Mock failed registry file download
     mock_response = Mock()
-    mock_response.status_code = 404
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "404 Client Error: Not Found for url"
+    )
     with patch("requests.get", return_value=mock_response) as mock_get_remote_registry:  # noqa: F841
         with pytest.raises(requests.exceptions.HTTPError):
             download_registry_from_github()
@@ -149,7 +151,9 @@ def test_update_registry_hash_mismatches_and_download_fails():
             mock_hash_response.text = "hash_doesn't_match123"
 
             mock_registry_response = Mock()
-            mock_registry_response.status_code = 404
+            mock_registry_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                "404 Client Error: Not Found for url"
+            )
 
             def which_mock_get(*args, **kwargs):
                 url = args[0]
@@ -174,8 +178,11 @@ def test_update_registry_hash_download_fails():
         with patch("pooch.file_hash", return_value="registryhash123") as mock_local_registry_hash:  # noqa: F841
             # Mock getting the remote hash/registry files
             mock_hash_response = Mock()
-            mock_hash_response.status_code = 404
+            mock_hash_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                "404 Client Error: Not Found for url"
+            )
+
             with patch("requests.get", return_value=mock_hash_response) as mock_get_remote_hash_file:  # noqa: F841
                 # Check that we get the expected exception
-                with pytest.raises(requests.exceptions.RequestException):
+                with pytest.raises(requests.exceptions.HTTPError):
                     download_registry_from_github()


### PR DESCRIPTION
For #54; checks the hash of the local registry file against the hash of the remote registry file to avoid unnecessary re-downloading of the registry file.

**Note** - the docs are failing because I've renamed the remote `data-registry.txt` to `data_registry.txt` to match our usage in lephare (default behavior is to save this file as `data_registry.txt`). Until we merge lephare-photoz/lephare-data#12, we won't be able to find this new file.