### PR TITLE
Update compile-cpp.yml to use macos-12

### DIFF
--- a/.github/workflows/compile-cpp.yml
+++ b/.github/workflows/compile-cpp.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy: 
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-14]
+        os: [ubuntu-latest, macos-12, macos-14]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The runner name `macos-latest` has been migrated from macos-12 to macos-14, so we need to specify macos-12 specifically. 

https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/