### PR TITLE
Specify ubuntu image for hosted runner

### DIFF
--- a/.github/workflows/compile-cpp.yml
+++ b/.github/workflows/compile-cpp.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy: 
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14]
+        os: [ubuntu-22.04, macos-12, macos-14]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We were bitten when the `macos-latest` alias was updated from os 12 to os 14. While there doesn't seem to be any rumors about doing a similar change for `ubuntu-latest`, we should go ahead and make that change as well, specifying the most current ubuntu OS version that github offers. 
