### PR TITLE
Remove `latest` alias in publish-to-pypi.yml

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,41 +25,41 @@ jobs:
         include:
 
           # Linux 64 bit manylinux2014
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python: 39
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
             python_version: "3.9"
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python: 310
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
             python_version: "3.10"
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python: 311
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
             python_version: "3.11"
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python: 312
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
             python_version: "3.12"
 
           # MacOS x86_64
-          - os: macos-latest
+          - os: macos-12
             python: 39
             platform_id: macosx_x86_64
             python_version: "3.9"
-          - os: macos-latest
+          - os: macos-12
             python: 310
             platform_id: macosx_x86_64
             python_version: "3.10"
-          - os: macos-latest
+          - os: macos-12
             python: 311
             platform_id: macosx_x86_64
             python_version: "3.11"
-          - os: macos-latest
+          - os: macos-12
             python: 312
             platform_id: macosx_x86_64
             python_version: "3.12"


### PR DESCRIPTION
Switching ubuntu-latest and macos-latest to specific versions for publishing to PyPI