### PR TITLE
fix a bug in test_filter.py, and add a check to the test suite

### DIFF
--- a/src/lephare/filter.py
+++ b/src/lephare/filter.py
@@ -60,8 +60,7 @@ class Filter(Runner):
         vec_flt = []
         for k, (f, t, c) in enumerate(zip(flt_files, transtyp, calibtyp)):
             flt_file = os.path.join(flt_rep, f)
-            one_filt = flt(k, f, t, c)
-            one_filt.read(flt_file)
+            one_filt = flt(k, flt_file, t, c)
             vec_flt.append(one_filt)
 
         write_output_filter(filtfile, filtdoc, vec_flt)

--- a/tests/lephare/test_filter.py
+++ b/tests/lephare/test_filter.py
@@ -22,6 +22,16 @@ def test_flt_class(filter_file):
     f = flt(-1, filter_file, trans=1, calib=1)
     assert f.width() == pytest.approx(241.9479, 1.0e-4)
     assert f.lambdaMean() == pytest.approx(5262.2831, 1.0e-4)
+    # testing relative path
+    tests_dir = os.path.abspath(os.path.curdir)
+    flt_dir = os.path.dirname(filter_file)
+    os.chdir(flt_dir)
+    print(os.path.abspath(os.path.curdir))
+    f2 = flt(-1, "./IB527.pb", trans=1, calib=1)
+    assert f2.width != 0.0
+    f3 = flt(-1, "IB527.pb", trans=1, calib=1)
+    assert f3.width != 0.0
+    os.chdir(tests_dir)
 
 
 def test_filtersvc(test_data_dir, filter_file):


### PR DESCRIPTION
In filter.py, flt::read is called after constructor, while now the C++ constructor already calls the method read.
Add relative path test for the filter filename input.