### PR TITLE
Exposing python scripts for command line use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,12 @@ dependencies = [
     "platformdirs",
 ]
 
+[project.scripts]
+filter = "lephare.filter:main"
+sedtolib = "lephare.sedtolib:main"
+mag_gal = "lephare.mag_gal:main"
+zphota = "lephare.zphota:main"
+
 [project.urls]
 "Source Code" = "https://github.com/lincc-frameworks/lephare"
 

--- a/src/lephare/filter.py
+++ b/src/lephare/filter.py
@@ -67,7 +67,11 @@ class Filter(Runner):
         write_output_filter(filtfile, filtdoc, vec_flt)
 
 
-if __name__ == "__main__":
+def main():
     runner = Filter()
     runner.run()
     runner.end()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lephare/mag_gal.py
+++ b/src/lephare/mag_gal.py
@@ -97,7 +97,11 @@ class MagGal(Runner):
         return
 
 
-if __name__ == "__main__":
+def main():
     runner = MagGal()
     runner.run()
     runner.end()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lephare/sedtolib.py
+++ b/src/lephare/sedtolib.py
@@ -21,6 +21,7 @@ sedtolib_config_keys = [
     "STAR_SED",
     "STAR_LIB",
     "STAR_FSCALE",
+    "LIB_ASCII",
 ]
 
 
@@ -85,7 +86,11 @@ class Sedtolib(Runner):
         return
 
 
-if __name__ == "__main__":
+def main():
     runner = Sedtolib()
     runner.run()
     runner.end()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lephare/zphota.py
+++ b/src/lephare/zphota.py
@@ -137,7 +137,11 @@ class Zphota(Runner):
         super().end()
 
 
-if __name__ == "__main__":
+def main():
     runner = Zphota()
     runner.run()
     runner.end()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lephare/zphota.py
+++ b/src/lephare/zphota.py
@@ -23,6 +23,7 @@ zphota_config_keys = [
     "ZPHOTLIB",
     "PARA_OUT",
     "CAT_OUT",
+    "VERBOSE",
     "CAT_TYPE",
     "ERR_SCALE",
     "ERR_FACTOR",
@@ -70,7 +71,6 @@ zphota_config_keys = [
     "LIMITS_MAPP_SEL",
     "LIMITS_MAPP_CUT",
     "Z_STEP",
-    "VERBOSE",
 ]
 
 nonestring = "NONE"
@@ -106,15 +106,10 @@ class Zphota(Runner):
                 self.keymap[k.upper()] = keyword(k.upper(), str(v))
         self.keymap["c"] = keyword("c", self.config)
 
-        print(self.keymap["Z_STEP"])
-        print(self.keymap["COSMOLOGY"])
-        print(self.keymap["Z_STEP"].split_double("0.1", 3))
-
         photoz = PhotoZ(self.keymap)
-        autoadapt = (self.keymap["AUTO_ADAPT"]).split_string("YES", 1)[0]
-        if autoadapt == "YES":
+        autoadapt = (self.keymap["AUTO_ADAPT"]).split_bool("NO", 1)[0]
+        if autoadapt:
             adapt_srcs = photoz.read_autoadapt_sources()
-            photoz.prep_data(adapt_srcs)
             a0, a1 = photoz.run_autoadapt(adapt_srcs)
             offsets = ",".join(np.array(a0).astype(str))
             offsets = "# Offsets from auto-adapt: " + offsets + "\n"
@@ -129,7 +124,6 @@ class Zphota(Runner):
         opa_out = GalMag.read_opa()  # noqa: F841
 
         fit_srcs = photoz.read_photoz_sources()
-        photoz.prep_data(fit_srcs)
         photoz.run_photoz(fit_srcs, a0, a1)
         photoz.write_outputs(fit_srcs, int(time.time()))
 


### PR DESCRIPTION
This PR exposes 4 python scripts that can be executed from the command line in the same way that the compiled C code was executed previously. 

For testing I used https://gitlab.lam.fr/Galaxies/LEPHARE/-/blob/master/tests/test_suite.sh?ref_type=heads and copied the commands over as identically as possibe. All of the code seems to be running as expected with the exception of zphota.

The commands that I am running to test are the following: 
```
(lephare) drew@ lephare % export LEPHAREDIR=/Users/drew/Library/Caches/lephare/data
(lephare) drew@ lephare % export LEPHAREWORK=/Users/drew/Library/Caches/lephare/work

(lephare) drew@ lephare % filter -c $LEPHAREDIR/examples/COSMOS.para

(lephare) drew@ lephare % sedtolib -c $LEPHAREDIR/examples/COSMOS.para -t S --STAR_SED $LEPHAREDIR/sed/STAR/STAR_MOD_ALL.list --LIB_ASCII YES

(lephare) drew@ lephare % maggal -c $LEPHAREDIR/examples/COSMOS.para -t S --LIB_ASCII YES --STAR_LIB_OUT ALLSTAR_COSMOS  

(lephare) drew@ lephare % sedtolib -c $LEPHAREDIR/examples/COSMOS.para -t Q --QSO_SED $LEPHAREDIR/sed/QSO/SALVATO09/AGN_MOD.list  

(lephare) drew@ lephare % maggal -c $LEPHAREDIR/examples/COSMOS.para -t Q --MOD_EXTINC 0,1000 --EB_V 0.,0.1,0.2,0.3 --EXTINC_LAW SB_calzetti.dat --LIB_ASCII NO --Z_STEP 0.04,0,6 --LIB_ASCII YES

(lephare) drew@ lephare % sedtolib -c $LEPHAREDIR/examples/COSMOS.para -t G --GAL_SED $LEPHAREDIR/examples/COSMOS_MOD.list --GAL_LIB LIB_VISTA 

(lephare) drew@ lephare % maggal -c $LEPHAREDIR/examples/COSMOS.para -t G --GAL_LIB_IN LIB_VISTA --GAL_LIB_OUT VISTA_COSMOS_FREE --MOD_EXTINC 18,26,26,33,26,33,26,33  --EXTINC_LAW SMC_prevot.dat,SB_calzetti.dat,SB_calzetti_bump1.dat,SB_calzetti_bump2.dat  --EM_LINES EMP_UV  --EM_DISPERSION 0.5,0.75,1.,1.5,2. --Z_STEP 0.04,0,6 --LIB_ASCII YES
```

All of which seem to be running as expected. I'm finding new output sent to my work directory and the files sizes are non-zero. 

When I run zphota though, I get segmentation fault errors. For reference, this is the zphota command that I am running: 
```
(lephare) drew@ lephare % zphota -c $LEPHAREDIR/examples/COSMOS.para --CAT_IN $LEPHAREDIR/examples/COSMOS.in --ZPHOTLIB VISTA_COSMOS_FREE,ALLSTAR_COSMOS,QSO_COSMOS  --ADD_EMLINES 0,100 --AUTO_ADAPT YES --Z_STEP 0.04,0,6 --CAT_LINES 1,100 --SPEC_OUT YES --PARA_OUT $LEPHAREDIR/examples/output.para --VERBOSE NO --ZFIX NO --PDZ_OUT $LEPHAREWORK/zphota/
```
And I get the following seg fault error message: `zsh: segmentation fault  zphota -c $LEPHAREDIR/examples/COSMOS.para --CAT_IN  --ZPHOTLIB  --ADD_EMLINE`

If I run the C++ executable with the same parameters, it _seems_ to run as expected. All of the output files that were produced by the version of lephare that Johann demonstrated at the beginning of the incubator are still produced and are have a non-zero size. They are placed in the wrong directory which is odd - they are ending up in the top level directory, which is neither $LEPHAREWORK nor $LEPHAREDIR.

