### PR TITLE
Specify `__all__` list in modules to avoid importing numpy and matplotlib

### DIFF
--- a/src/lephare/_spec.py
+++ b/src/lephare/_spec.py
@@ -1,6 +1,10 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
+__all__ = [
+    "plotspec",
+]
+
 
 def plotspec(filename):
     ### Open .spec file[s] and read the parameters

--- a/src/lephare/data_manager.py
+++ b/src/lephare/data_manager.py
@@ -3,6 +3,10 @@ import os
 
 from platformdirs import user_cache_dir
 
+__all__ = [
+    "DataManager",
+]
+
 
 class DataManager:
     def __init__(self):

--- a/src/lephare/runner.py
+++ b/src/lephare/runner.py
@@ -4,6 +4,10 @@ import time
 
 from lephare._lephare import get_lephare_env, keyword
 
+__all__ = [
+    "Runner",
+]
+
 
 class Runner:
     """Base class holding config values for running all stages.


### PR DESCRIPTION
This change prevent the inclusion of numpy and matplotlib in the lephare namespace by specifying the `__all__` list in the few modules that didn't already have one. 