### PR TITLE
Allow creation of a descriptive run directory

### DIFF
--- a/src/lephare/data_manager.py
+++ b/src/lephare/data_manager.py
@@ -122,6 +122,10 @@ class DataManager:
         # timestamped run directory.
         if descriptive_directory_name is not None:
             run_directory = os.path.realpath(f"{lephare_work_dir}/../{descriptive_directory_name}")
+            if os.path.isdir(run_directory):
+                raise FileExistsError(
+                    f"The directory {run_directory} already exists. Please choose another name."
+                )
         else:
             now = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
             run_directory = os.path.realpath(f"{lephare_work_dir}/../{now}")

--- a/src/lephare/data_manager.py
+++ b/src/lephare/data_manager.py
@@ -172,7 +172,6 @@ class DataManager:
                     empty = False
                     break
             if empty:
-                print(f"-> Removing empty run directory: {run_dir}")
                 for sub_dir in work_sub_directories:
                     os.rmdir(os.path.join(run_dir, sub_dir))
                 os.rmdir(run_dir)

--- a/src/lephare/data_manager.py
+++ b/src/lephare/data_manager.py
@@ -163,11 +163,9 @@ class DataManager:
 
         # Remove empty directories (only if all subdirs are empty)
         for run_name in os.listdir(runs_dir):
-            # print(run_name)
             run_dir = os.path.join(runs_dir, run_name)
             empty = True
             for sub_dir in work_sub_directories:
-                # print(os.listdir(os.path.join(run_dir, sub_dir)))
                 if len(os.listdir(os.path.join(run_dir, sub_dir))) > 0:
                     empty = False
                     break

--- a/src/lephare/data_manager.py
+++ b/src/lephare/data_manager.py
@@ -88,10 +88,22 @@ class DataManager:
                 be written to {self.lephare_work_dir}."""
             )
 
-    def create_new_run(self):
+    def create_new_run(self, descriptive_directory_name=None):
         """Create a timestamped directory to contain the output from the current run.
         The newly created timestamped directory is symlinked to the path defined
-        by the LEPHAREWORK environment variable."""
+        by the LEPHAREWORK environment variable.
+
+        Parameters
+        ----------
+        descriptive_directory_name: str
+            A descriptive name for the new run directory. If None, the directory
+            will be named with the current timestamp.
+
+        Returns
+        -------
+        run_directory : str
+            The path to the newly created run directory.
+        """
 
         lephare_work_dir = os.getenv("LEPHAREWORK", None)
 
@@ -106,9 +118,14 @@ class DataManager:
                                information on how to set up the directory structure."""
             )
 
-        # given that LEPHAREWORK is a symlink, create a new timestamped run directory
-        now = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
-        run_directory = os.path.realpath(f"{lephare_work_dir}/../{now}")
+        # given that LEPHAREWORK is a symlink, create a new descriptive or
+        # timestamped run directory.
+        if descriptive_directory_name is not None:
+            run_directory = os.path.realpath(f"{lephare_work_dir}/../{descriptive_directory_name}")
+        else:
+            now = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+            run_directory = os.path.realpath(f"{lephare_work_dir}/../{now}")
+
         print(f"Creating new run directory at {run_directory}.")
         os.makedirs(run_directory, exist_ok=True)
 
@@ -119,6 +136,8 @@ class DataManager:
 
         # create the subdirectories in the new run directory
         self.create_work_subdirectories(run_directory)
+
+        return run_directory
 
     def create_work_subdirectories(self, parent_dir):
         """Creates the required work subdirectories in the parent directory if they

--- a/src/lephare/data_manager.py
+++ b/src/lephare/data_manager.py
@@ -149,3 +149,35 @@ class DataManager:
         work_sub_directories = ["filt", "lib_bin", "lib_mag", "zphota"]
         for sub_dir in work_sub_directories:
             os.makedirs(os.path.join(parent_dir, sub_dir), exist_ok=True)
+
+    def remove_empty_run_directories(self):
+        """Remove any empty run directories from the cache. If any file exists in
+        any of the subdirectories, the run directory is not considered empty.
+        Note that we generate a new run directory if the work directory is no longer
+        a symlink."""
+        default_os_cache = user_cache_dir("lephare", ensure_exists=True)
+        work_sub_directories = ["filt", "lib_bin", "lib_mag", "zphota"]
+        runs_dir = os.path.join(default_os_cache, "runs")
+        work_dir = os.path.join(default_os_cache, "work")
+        symlink_target = os.readlink(work_dir)
+
+        # Remove empty directories (only if all subdirs are empty)
+        for run_name in os.listdir(runs_dir):
+            # print(run_name)
+            run_dir = os.path.join(runs_dir, run_name)
+            empty = True
+            for sub_dir in work_sub_directories:
+                # print(os.listdir(os.path.join(run_dir, sub_dir)))
+                if len(os.listdir(os.path.join(run_dir, sub_dir))) > 0:
+                    empty = False
+                    break
+            if empty:
+                print(f"-> Removing empty run directory: {run_dir}")
+                for sub_dir in work_sub_directories:
+                    os.rmdir(os.path.join(run_dir, sub_dir))
+                os.rmdir(run_dir)
+
+        # If we removed the work dir's symlink target, replace with new run dir:
+        if symlink_target not in os.listdir(runs_dir):
+            print("Work directory is no longer a symlink. Creating new run.")
+            self.create_new_run()

--- a/src/lephare/runner.py
+++ b/src/lephare/runner.py
@@ -44,7 +44,7 @@ class Runner:
         if config_keymap is None and config_file is None:
             # this only happens if the code is called as an executed script
             # Consider the keywords given in the line command
-            self.args = self.config_parser(config_keys)
+            self.args = self.config_parser()
             if self.timer:
                 self.start = time.time()
         # set verbosity. check keymap is not set on the commandline.
@@ -89,14 +89,8 @@ class Runner:
 
         self.keymap = keymap
 
-    def config_parser(self, config_keys):
-        """Create command line config parser from list of keys
-
-        Parameters
-        ----------
-        config_keys : `list`
-            List of all config keys
-        """
+    def config_parser(self):
+        """Create command line config parser from list of keys"""
         parser = argparse.ArgumentParser(add_help=False)
         # No required positional argument as in the C++ code, though in there
         # absence of the config file results in exiting. Need to understand whether

--- a/tests/lephare/test_data_manager.py
+++ b/tests/lephare/test_data_manager.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import time
+from unittest.mock import patch
 
 import pytest
 from lephare import data_manager as dm
@@ -23,6 +24,22 @@ def test_data_manager_with_predefined_directories(unset_env_vars):
     assert new_dm.LEPHAREWORK == "/tmp2"
 
 
+def test_data_manager_with_predefined_dir_directory(unset_env_vars):
+    """Test DataManager with predefined dir directory"""
+    os.environ["LEPHAREDIR"] = "/tmp1"
+    new_dm = dm.DataManager()
+    assert new_dm.LEPHAREDIR == "/tmp1"
+    assert new_dm.LEPHAREWORK is None
+
+
+def test_data_manager_with_predefined_work_directory(unset_env_vars):
+    """Test DataManager with predefined work directory"""
+    os.environ["LEPHAREWORK"] = "/tmp2"
+    new_dm = dm.DataManager()
+    assert new_dm.LEPHAREDIR is None
+    assert new_dm.LEPHAREWORK == "/tmp2"
+
+
 def test_data_manager_configure_directories_with_default(unset_env_vars):
     """Test DataManager configure_directories method with default directories"""
     new_dm = dm.DataManager()
@@ -35,8 +52,9 @@ def test_data_manager_configure_directories_with_default(unset_env_vars):
     assert expected_work_directory == new_dm.LEPHAREWORK
 
 
-def test_create_new_run():
-    """Make sure that new run directory structure is created"""
+def test_create_new_run_with_unlinked_work_dir():
+    """Make sure that a runtime error is raised when we attempt to create a new
+    run directory structure within a pre-existing and un-linked work directory"""
     with pytest.raises(RuntimeError):
         with tempfile.TemporaryDirectory() as tmpdir:
             os.environ["LEPHAREWORK"] = tmpdir
@@ -44,12 +62,50 @@ def test_create_new_run():
             new_dm.create_new_run()
 
 
-def test_create_new_run_with_existing_run_directory(unset_env_vars):
-    """Make sure that no exceptions are raised if the run directory already exists"""
-    new_dm = dm.DataManager()
-    new_dm.configure_directories()
-    time.sleep(1)
-    new_dm.create_new_run()
+def test_create_new_run_in_mock_cache_dir(unset_env_vars):
+    """Make sure that the expected directory structure is created in a mock cache
+    directory"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("lephare.data_manager.user_cache_dir", return_value=tmpdir):
+            new_dm = dm.DataManager()
+            new_dm.configure_directories()
+            assert len(os.listdir(os.path.join(tmpdir, "runs"))) == 1
+
+
+def test_create_new_run_creates_symlink(unset_env_vars):
+    """Make sure that the expected symlinked directory structure is created"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("lephare.data_manager.user_cache_dir", return_value=tmpdir):
+            # Set up data manager and make a run
+            new_dm = dm.DataManager()
+            new_dm.configure_directories()
+            new_dm.create_new_run()
+            # Check work directory exists
+            assert os.path.isdir(os.path.join(tmpdir, "work"))
+            # Check the symlink exists
+            assert os.path.islink(os.path.join(tmpdir, "work"))
+            assert os.readlink(os.path.join(tmpdir, "work")) == os.path.join(
+                tmpdir, "runs", os.listdir(os.path.join(tmpdir, "runs"))[0]
+            )
+
+
+def test_create_new_run_overwrites_symlink(unset_env_vars):
+    """Make sure that the expected symlinked directory structure is created, and
+    the previous symlink is overwritten"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("lephare.data_manager.user_cache_dir", return_value=tmpdir):
+            # Set up data manager and make a run
+            new_dm = dm.DataManager()
+            new_dm.configure_directories()
+            new_dm.create_new_run()
+            # Sleep for a second to ensure the timestamp is different
+            time.sleep(1)
+            # Create a new run
+            new_dm.create_new_run()
+            # Check the symlink has been moved from the original directory to new directory
+            sorted_timestamped_dirs = sorted(os.listdir(os.path.join(tmpdir, "runs")))
+            assert os.readlink(os.path.join(tmpdir, "work")) != sorted_timestamped_dirs[0]
+            assert os.readlink(os.path.join(tmpdir, "work")) != sorted_timestamped_dirs[-1]
 
 
 def test_create_work_subdirectories():
@@ -61,12 +117,12 @@ def test_create_work_subdirectories():
         assert os.path.isdir(os.path.join(tmpdir, "lib_bin"))
         assert os.path.isdir(os.path.join(tmpdir, "lib_mag"))
         assert os.path.isdir(os.path.join(tmpdir, "zphota"))
+        assert len(os.listdir(tmpdir)) == 4
 
 
 def test_create_work_subdirectories_with_existing_directories():
     """Makes sure that no exceptions are raised if the directories already exist
     and ensure that existing files are not overwritten or deleted."""
-
     # Create a temp directory
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create the `filt` directory and add a test file to it
@@ -85,3 +141,82 @@ def test_create_work_subdirectories_with_existing_directories():
         # Ensure the test file is still there
         with open(os.path.join(tmpdir, "filt", "test.txt"), "r") as file:
             assert file.read() == "test"
+
+
+def test_remove_empty_run_directories(unset_env_vars):
+    """Make sure that the method to remove empty run directories does remove
+    empty directories."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("lephare.data_manager.user_cache_dir", return_value=tmpdir):
+            runs_dir = os.path.join(tmpdir, "runs")
+            # Set up data manager and make a run
+            new_dm = dm.DataManager()
+            new_dm.configure_directories()
+            new_dm.create_new_run()
+            # Assert there's just one run directory
+            assert len(os.listdir(runs_dir)) == 1
+            # Make more (sleeping to ensure timestamps are different)
+            time.sleep(1)
+            new_dm.create_new_run()
+            time.sleep(1)
+            new_dm.create_new_run()
+            # Assert there are now three run directories
+            assert len(os.listdir(runs_dir)) == 3
+            # Remove the empty run directories
+            new_dm.remove_empty_run_directories()
+            # Assert there's just one run directory (the new one created to preserve symlink)
+            assert len(os.listdir(runs_dir)) == 1
+
+
+def test_remove_empty_skips_nonempty_symlinked_run(unset_env_vars):
+    """Make sure that the method to remove empty run directories does not remove
+    non-empty directories. This is the case where the non-empty directory is the
+    symlinked work directory, so we do not need to generate a new run directory
+    to preserve the symlink."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("lephare.data_manager.user_cache_dir", return_value=tmpdir):
+            # Set up data manager and make three runs (sleeping for diff timestamps)
+            new_dm = dm.DataManager()
+            new_dm.configure_directories()
+            new_dm.create_new_run()
+            time.sleep(1)
+            new_dm.create_new_run()
+            time.sleep(1)
+            new_dm.create_new_run()
+            # Assert there are now three run directories
+            assert len(os.listdir(os.path.join(tmpdir, "runs"))) == 3
+            # Create a file in the most recent run directory
+            most_recent_run = sorted(os.listdir(os.path.join(tmpdir, "runs")))[-1]
+            with open(os.path.join(tmpdir, "runs", most_recent_run, "filt", "test.txt"), "w") as file:
+                file.write("not empty!")
+            # Remove the empty run directories
+            new_dm.remove_empty_run_directories()
+            # Assert there's just one run directory
+            assert len(os.listdir(os.path.join(tmpdir, "runs"))) == 1
+
+
+def test_remove_empty_skips_nonempty_non_symlinked_run(unset_env_vars):
+    """Make sure that the method to remove empty run directories does not remove
+    non-empty directories. This is the case where the non-empty directory is not
+    the symlinked work directory, so we need to generate a new run directory to
+    preserve the symlink."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("lephare.data_manager.user_cache_dir", return_value=tmpdir):
+            # Set up data manager and make three runs (sleeping for diff timestamps)
+            new_dm = dm.DataManager()
+            new_dm.configure_directories()
+            new_dm.create_new_run()
+            time.sleep(1)
+            new_dm.create_new_run()
+            time.sleep(1)
+            new_dm.create_new_run()
+            # Assert there are now three run directories
+            assert len(os.listdir(os.path.join(tmpdir, "runs"))) == 3
+            # Create a file in the first run directory
+            first_run = sorted(os.listdir(os.path.join(tmpdir, "runs")))[0]
+            with open(os.path.join(tmpdir, "runs", first_run, "filt", "test.txt"), "w") as file:
+                file.write("not empty!")
+            # Remove the empty run directories
+            new_dm.remove_empty_run_directories()
+            # Assert there's two run directories: the non-empty one and the new one
+            assert len(os.listdir(os.path.join(tmpdir, "runs"))) == 2

--- a/tests/lephare/test_runner.py
+++ b/tests/lephare/test_runner.py
@@ -1,8 +1,7 @@
 import os
 
-import pytest
-
 import lephare as lp
+import pytest
 from lephare._lephare import keyword
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))

--- a/tests/lephare/test_runner.py
+++ b/tests/lephare/test_runner.py
@@ -89,3 +89,80 @@ def test_runner_config_file_not_found():
     with pytest.raises(RuntimeError) as excinfo:
         _ = lp.Runner(config_keys=test_keys, config_file=config_file_path)
         assert excinfo.value == f"File {config_file_path} not found"
+
+
+def test_command_line_argument_parsing_basic(monkeypatch):
+    """Check to make sure that command line arguments are parsed correctly."""
+    test_keys = ["key1", "key2", "key3"]
+    monkeypatch.setattr("sys.argv", ["runner.py", "--key1", "foo", "--key2", "42"])
+    runner = lp.Runner(config_keys=test_keys)
+
+    assert runner.keymap["key1"].value == "foo"
+    assert runner.keymap["key2"].value == "42"
+    assert runner.keymap["key3"].value == ""
+    assert len(runner.keymap) == 3
+    assert runner.args.config == ""
+    assert runner.args.timer is False
+    assert runner.args.verbose is False
+
+
+def test_command_line_argument_parsing_with_known_args(monkeypatch):
+    """Check to make sure that command line arguments are parsed correctly when
+    including known arguments."""
+    test_keys = ["key1", "key2", "key3"]
+    config_file_path = os.path.join(TESTDATADIR, "examples/COSMOS.para")
+    monkeypatch.setattr(
+        "sys.argv", ["runner.py", "--key1", "foo", "--key2", "42", "--config", config_file_path, "--timer"]
+    )
+    runner = lp.Runner(config_keys=test_keys)
+
+    assert runner.keymap["key1"].value == "foo"
+    assert runner.keymap["key2"].value == "42"
+    assert runner.keymap["key3"].value == ""
+    assert runner.keymap["QSO_FSCALE"].value == "1."
+    assert len(runner.keymap) > 3
+    assert runner.args.config == config_file_path
+    assert runner.args.timer is True
+    assert runner.args.verbose is False
+    with pytest.raises(AttributeError) as excinfo:
+        _ = runner.args.typ
+        assert excinfo.value == "'Runner' object has no attribute 'typ'"
+
+
+def test_command_line_argument_parsing_with_subclass(monkeypatch):
+    """Want to cover the case where the `typ` argument is passed to the runner."""
+
+    class Sedtolib(lp.Runner):
+        @property
+        def __class__(self):
+            return type("Sedtolib", (object,), {})
+
+    test_keys = ["key1", "key2", "key3"]
+    config_file_path = os.path.join(TESTDATADIR, "examples/COSMOS.para")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "runner.py",
+            "--typ",
+            "BAR",
+            "--key1",
+            "foo",
+            "--key2",
+            "42",
+            "--config",
+            config_file_path,
+            "--timer",
+        ],
+    )
+    runner = Sedtolib(config_keys=test_keys)
+
+    assert runner.keymap["key1"].value == "foo"
+    assert runner.keymap["key2"].value == "42"
+    assert runner.keymap["key3"].value == ""
+    assert runner.keymap["QSO_FSCALE"].value == "1."
+    assert len(runner.keymap) > 3
+    assert runner.args.config == config_file_path
+    assert runner.args.timer is True
+    assert runner.args.verbose is False
+    assert runner.args.typ == "BAR"
+    assert runner.typ == "BAR"


### PR DESCRIPTION
This PR doesn't have a corresponding issue, but stems from the conversation between Alex, Raphael and myself regarding the best way to handle running multiple slightly different instances of the Inform stage in RAIL and the best way to handle tracking the intermediate files of each in the most straightforward way possible. 

The approach implemented here will allow a user to request a new run directory be created with a user defined name. The resulting directory path will be returned. We anticipate using the `name` stage parameter from the Inform stage to define the directory name. Then we can include this in the output model file, and use that to read in the run directory path in the estimation stage. 