### PR TITLE
Additional test coverage for `Runner.config_parser`

### DIFF
--- a/src/lephare/runner.py
+++ b/src/lephare/runner.py
@@ -44,7 +44,7 @@ class Runner:
         if config_keymap is None and config_file is None:
             # this only happens if the code is called as an executed script
             # Consider the keywords given in the line command
-            self.args = self.config_parser(config_keys)
+            self.args = self.config_parser()
             if self.timer:
                 self.start = time.time()
         # set verbosity. check keymap is not set on the commandline.
@@ -89,14 +89,8 @@ class Runner:
 
         self.keymap = keymap
 
-    def config_parser(self, config_keys):
-        """Create command line config parser from list of keys
-
-        Parameters
-        ----------
-        config_keys : `list`
-            List of all config keys
-        """
+    def config_parser(self):
+        """Create command line config parser from list of keys"""
         parser = argparse.ArgumentParser(add_help=False)
         # No required positional argument as in the C++ code, though in there
         # absence of the config file results in exiting. Need to understand whether

--- a/tests/lephare/test_runner.py
+++ b/tests/lephare/test_runner.py
@@ -124,6 +124,9 @@ def test_command_line_argument_parsing_with_known_args(monkeypatch):
     assert runner.args.config == config_file_path
     assert runner.args.timer is True
     assert runner.args.verbose is False
+    with pytest.raises(AttributeError) as excinfo:
+        _ = runner.args.typ
+        assert excinfo.value == "'Runner' object has no attribute 'typ'"
 
 
 def test_command_line_argument_parsing_with_subclass(monkeypatch):


### PR DESCRIPTION
Using monkeypatch to set the sys.argv parameters so that we can test the behavior of the config_parser method. I also make use of a inline class that looks like Sedtolib so that we can check for setting `typ`. 

Also, in the process of writing the tests, I noticed that the input variable defined for `config_parser` wasn't actually used, so I've removed it, the docstring describing it, and updated the single location where config_parser is called from the `__init__` method.