### PR TITLE
Fix memory leak

### DIFF
--- a/src/lib/photoz_lib.h
+++ b/src/lib/photoz_lib.h
@@ -47,8 +47,15 @@ class PhotoZ {
   PhotoZ(keymap &key_analysed);
 
   virtual ~PhotoZ() {
+    for (auto &sed: fullLib)
+      delete sed;
+    for (auto &sed: fullLibIR)
+      delete sed;
+    for (auto &sed: lightLib)
+      delete sed;
     fullLib.clear();
     fullLibIR.clear();
+    lightLib.clear();
   }
 
   std::tuple<vector<double>, vector<double>> run_autoadapt(vector<onesource *>);

--- a/src/lib/photoz_lib.h
+++ b/src/lib/photoz_lib.h
@@ -47,12 +47,9 @@ class PhotoZ {
   PhotoZ(keymap &key_analysed);
 
   virtual ~PhotoZ() {
-    for (auto &sed: fullLib)
-      delete sed;
-    for (auto &sed: fullLibIR)
-      delete sed;
-    for (auto &sed: lightLib)
-      delete sed;
+    for (auto &sed: fullLib) delete sed;
+    for (auto &sed: fullLibIR) delete sed;
+    for (auto &sed: lightLib) delete sed;
     fullLib.clear();
     fullLibIR.clear();
     lightLib.clear();

--- a/src/lib/photoz_lib.h
+++ b/src/lib/photoz_lib.h
@@ -47,9 +47,9 @@ class PhotoZ {
   PhotoZ(keymap &key_analysed);
 
   virtual ~PhotoZ() {
-    for (auto &sed: fullLib) delete sed;
-    for (auto &sed: fullLibIR) delete sed;
-    for (auto &sed: lightLib) delete sed;
+    for (auto &sed : fullLib) delete sed;
+    for (auto &sed : fullLibIR) delete sed;
+    for (auto &sed : lightLib) delete sed;
     fullLib.clear();
     fullLibIR.clear();
     lightLib.clear();


### PR DESCRIPTION
## Change Description
Hello, this fixes leaking SED instances if they still exist when calling the `PhotoZ` class destructor (this is the case when running lephare with pz-rail-lephare). The relevant leaks, shown by the address sanitizer:

```
Direct leak of 2358756400 byte(s) in 5360810 object(s) allocated from:
    #0 0x2b20a2157d77 in operator new(unsigned long) /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x2b20d6e0a224 in PhotoZ::read_lib(std::vector<SED*, std::allocator<SED*> >&, int&, int*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::vector<int, std::allocator<int> >, int&) /lustre/t1/cl/lsst/tmp/henrique.almeida/lephare/src/lib/photoz_lib.cpp:561

Direct leak of 77133056 byte(s) in 219128 object(s) allocated from:
    #0 0x2b20a2157d77 in operator new(unsigned long) /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x2b20d6e09dd1 in PhotoZ::read_lib(std::vector<SED*, std::allocator<SED*> >&, int&, int*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::vector<int, std::allocator<int> >, int&) /lustre/t1/cl/lsst/tmp/henrique.almeida/lephare/src/lib/photoz_lib.cpp:565

(...)
Direct leak of 1162304 byte(s) in 3302 object(s) allocated from:
    #0 0x2b20a2157d77 in operator new(unsigned long) /opt/conda/conda-bld/gcc-compiler_1654084175708/work/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x2b20d6e09472 in PhotoZ::read_lib(std::vector<SED*, std::allocator<SED*> >&, int&, int*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::vector<int, std::allocator<int> >, int&) /lustre/t1/cl/lsst/tmp/henrique.almeida/lephare/src/lib/photoz_lib.cpp:567


```


- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
Completed the destructor with the remaining de-allocations.


## Code Quality
- [ ] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
