### PR TITLE
Avoid repeated indirect access to dictionaries and multi-dimensional vectors

### DIFF
--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -844,17 +844,36 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] /
   // 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] /
   // 11:["BAY_ZG"] / 12:["BAY_ZQ"]
-  vector<double> PDFzloc(pdfmap[11].size(), 0.);
-  vector<double> PDFzqloc(pdfmap[12].size(), 0.);
-  vector<double> PDFmassloc(pdfmap[0].size(), 0.);
-  vector<double> PDFSFRloc(pdfmap[1].size(), 0.);
-  vector<double> PDFsSFRloc(pdfmap[2].size(), 0.);
-  vector<double> PDFAgeloc(pdfmap[5].size(), 0.);
-  vector<double> PDFLdustloc(pdfmap[3].size(), 0.);
-  vector<double> PDFcol1loc(pdfmap[6].size(), 0.);
-  vector<double> PDFcol2loc(pdfmap[7].size(), 0.);
-  vector<double> PDFmrefloc(pdfmap[8].size(), 0.);
-  
+  double PDFzloc[pdfmap[11].size()];
+  for (size_t i = 0; i < pdfmap[11].size(); ++i) PDFzloc[i] = 0.0;
+
+  double PDFzqloc[pdfmap[12].size()];
+  for (size_t i = 0; i < pdfmap[12].size(); ++i) PDFzqloc[i] = 0.0;
+
+  double PDFmassloc[pdfmap[0].size()];
+  for (size_t i = 0; i < pdfmap[0].size(); ++i) PDFmassloc[i] = 0.0;
+
+  double PDFSFRloc[pdfmap[1].size()];
+  for (size_t i = 0; i < pdfmap[1].size(); ++i) PDFSFRloc[i] = 0.0;
+
+  double PDFsSFRloc[pdfmap[2].size()];
+  for (size_t i = 0; i < pdfmap[2].size(); ++i) PDFsSFRloc[i] = 0.0;
+
+  double PDFAgeloc[pdfmap[5].size()];
+  for (size_t i = 0; i < pdfmap[5].size(); ++i) PDFAgeloc[i] = 0.0;
+
+  double PDFLdustloc[pdfmap[3].size()];
+  for (size_t i = 0; i < pdfmap[3].size(); ++i) PDFLdustloc[i] = 0.0;
+
+  double PDFcol1loc[pdfmap[6].size()];
+  for (size_t i = 0; i < pdfmap[6].size(); ++i) PDFcol1loc[i] = 0.0;
+
+  double PDFcol2loc[pdfmap[7].size()];
+  for (size_t i = 0; i < pdfmap[7].size(); ++i) PDFcol2loc[i] = 0.0;
+
+  double PDFmrefloc[pdfmap[8].size()];
+  for (size_t i = 0; i < pdfmap[8].size(); ++i) PDFmrefloc[i] = 0.0;
+
   // Decide if the uncertainties on the rest-frame colors should be analysed
   bool colAnalysis;
   colAnalysis = ((fltColRF[0] >= 0) && (fltColRF[1] >= 0) &&
@@ -877,18 +896,15 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
 
   // parrallellize over each SED
 #ifdef _OPENMP
-#pragma omp declare reduction(vec_add : vector<double> : transform(      \
-	omp_out.begin(), omp_out.end(), omp_in.begin(), omp_out.begin(), \
-	plus<double>()))
-
+  // double start = omp_get_wtime();
 #pragma omp parallel private(pos, col1, col2, rfSED, prob) firstprivate( \
         thread_id, dimzg, number_threads) shared(locChi2, locInd, fulllib)
   {
     // Catch the name of the local thread in the parallelisation
     thread_id = omp_get_thread_num();
-#pragma omp for schedule(static, 10000) reduction(                      \
-        vec_add : PDFzloc, PDFzqloc, PDFmassloc, PDFSFRloc, PDFsSFRloc, \
-	PDFAgeloc, PDFLdustloc, PDFcol1loc, PDFcol2loc, PDFmrefloc) nowait
+#pragma omp for schedule(static, 10000) reduction(                           \
+        + : PDFzloc, PDFzqloc, PDFmassloc, PDFSFRloc, PDFsSFRloc, PDFAgeloc) \
+    nowait
 #endif
     // Loop over all SEDs, which is parallelized
     for (size_t i = 0; i < va.size(); i++) {
@@ -1032,16 +1048,16 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] /
   // 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] /
   // 11:["BAY_ZG"] / 12:["BAY_ZQ"] Put back 1 dimension array into PDF objects
-  pdfbayzg.vPDF.assign(PDFzloc.begin(), PDFzloc.end());
-  pdfbayzq.vPDF.assign(PDFzqloc.begin(), PDFzqloc.end());
-  pdfmass.vPDF.assign(PDFmassloc.begin(), PDFmassloc.end());
-  pdfsfr.vPDF.assign(PDFSFRloc.begin(), PDFSFRloc.end());
-  pdfssfr.vPDF.assign(PDFsSFRloc.begin(), PDFsSFRloc.end());
-  pdfage.vPDF.assign(PDFAgeloc.begin(), PDFAgeloc.end());
-  pdfldust.vPDF.assign(PDFLdustloc.begin(), PDFLdustloc.end());
-  pdfcol1.vPDF.assign(PDFcol1loc.begin(), PDFcol1loc.end());
-  pdfcol2.vPDF.assign(PDFcol2loc.begin(), PDFcol2loc.end());
-  pdfmref.vPDF.assign(PDFmrefloc.begin(), PDFmrefloc.end());
+  pdfbayzg.vPDF.assign((PDFzloc), (PDFzloc + pdfbayzg.size()));
+  pdfbayzq.vPDF.assign((PDFzqloc), (PDFzqloc + pdfbayzq.size()));
+  pdfmass.vPDF.assign((PDFmassloc), (PDFmassloc + pdfmass.size()));
+  pdfsfr.vPDF.assign((PDFSFRloc), (PDFSFRloc + pdfsfr.size()));
+  pdfssfr.vPDF.assign((PDFsSFRloc), (PDFsSFRloc + pdfssfr.size()));
+  pdfage.vPDF.assign((PDFAgeloc), (PDFAgeloc + pdfage.size()));
+  pdfldust.vPDF.assign((PDFLdustloc), (PDFLdustloc + pdfldust.size()));
+  pdfcol1.vPDF.assign((PDFcol1loc), (PDFcol1loc + pdfcol1.size()));
+  pdfcol2.vPDF.assign((PDFcol2loc), (PDFcol2loc + pdfcol2.size()));
+  pdfmref.vPDF.assign((PDFmrefloc), (PDFmrefloc + pdfmref.size()));
 
   // Normalize the PDF
 

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -1048,16 +1048,16 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] /
   // 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] /
   // 11:["BAY_ZG"] / 12:["BAY_ZQ"] Put back 1 dimension array into PDF objects
-  pdfbayzg.vPDF.assign((PDFzloc), (PDFzloc + pdfbayzg.size()));
-  pdfbayzq.vPDF.assign((PDFzqloc), (PDFzqloc + pdfbayzq.size()));
-  pdfmass.vPDF.assign((PDFmassloc), (PDFmassloc + pdfmass.size()));
-  pdfsfr.vPDF.assign((PDFSFRloc), (PDFSFRloc + pdfsfr.size()));
-  pdfssfr.vPDF.assign((PDFsSFRloc), (PDFsSFRloc + pdfssfr.size()));
-  pdfage.vPDF.assign((PDFAgeloc), (PDFAgeloc + pdfage.size()));
-  pdfldust.vPDF.assign((PDFLdustloc), (PDFLdustloc + pdfldust.size()));
-  pdfcol1.vPDF.assign((PDFcol1loc), (PDFcol1loc + pdfcol1.size()));
-  pdfcol2.vPDF.assign((PDFcol2loc), (PDFcol2loc + pdfcol2.size()));
-  pdfmref.vPDF.assign((PDFmrefloc), (PDFmrefloc + pdfmref.size()));
+  pdfbayzg.vPDF.assign((PDFzloc), (PDFzloc+pdfbayzg.size()));
+  pdfbayzq.vPDF.assign((PDFzqloc), (PDFzqloc+pdfbayzq.size()));
+  pdfmass.vPDF.assign((PDFmassloc), (PDFmassloc+pdfmass.size()));
+  pdfsfr.vPDF.assign((PDFSFRloc), (PDFSFRloc+pdfsfr.size()));
+  pdfssfr.vPDF.assign((PDFsSFRloc), (PDFsSFRloc+pdfssfr.size()));
+  pdfage.vPDF.assign((PDFAgeloc), (PDFAgeloc+pdfage.size()));
+  pdfldust.vPDF.assign((PDFLdustloc), (PDFLdustloc+pdfldust.size()));
+  pdfcol1.vPDF.assign((PDFcol1loc), (PDFcol1loc+pdfcol1.size()));
+  pdfcol2.vPDF.assign((PDFcol2loc), (PDFcol2loc+pdfcol2.size()));
+  pdfmref.vPDF.assign((PDFmrefloc), (PDFmrefloc+pdfmref.size()));
 
   // Normalize the PDF
 

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -877,15 +877,18 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
 
   // parrallellize over each SED
 #ifdef _OPENMP
-#pragma omp declare reduction(vec_add : vector<double> : transform(omp_out.begin(), omp_out.end(), omp_in.begin(), omp_out.begin(), plus<double>()))
-    //    initializer(omp_priv = decltype(omp_orig)(omp_orig.size()))
-  // double start = omp_get_wtime();
+#pragma omp declare reduction(vec_add : vector<double> : transform(      \
+	omp_out.begin(), omp_out.end(), omp_in.begin(), omp_out.begin(), \
+	plus<double>()))
+
 #pragma omp parallel private(pos, col1, col2, rfSED, prob) firstprivate( \
         thread_id, dimzg, number_threads) shared(locChi2, locInd, fulllib)
   {
     // Catch the name of the local thread in the parallelisation
     thread_id = omp_get_thread_num();
-#pragma omp for schedule(static, 10000) reduction( vec_add : PDFzloc, PDFzqloc, PDFmassloc, PDFSFRloc, PDFsSFRloc, PDFAgeloc, PDFLdustloc, PDFcol1loc, PDFcol2loc, PDFmrefloc) nowait
+#pragma omp for schedule(static, 10000) reduction(                      \
+        vec_add : PDFzloc, PDFzqloc, PDFmassloc, PDFSFRloc, PDFsSFRloc, \
+	PDFAgeloc, PDFLdustloc, PDFcol1loc, PDFcol2loc, PDFmrefloc) nowait
 #endif
     // Loop over all SEDs, which is parallelized
     for (size_t i = 0; i < va.size(); i++) {
@@ -1029,16 +1032,16 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] /
   // 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] /
   // 11:["BAY_ZG"] / 12:["BAY_ZQ"] Put back 1 dimension array into PDF objects
-  pdfbayzg.vPDF.assign( PDFzloc.begin(), PDFzloc.end() );
-  pdfbayzq.vPDF.assign( PDFzqloc.begin(), PDFzqloc.end() );
-  pdfmass.vPDF.assign(  PDFmassloc.begin(), PDFmassloc.end());
-  pdfsfr.vPDF.assign(   PDFSFRloc.begin(), PDFSFRloc.end());
-  pdfssfr.vPDF.assign(  PDFsSFRloc.begin(), PDFsSFRloc.end());
-  pdfage.vPDF.assign(   PDFAgeloc.begin(), PDFAgeloc.end());
-  pdfldust.vPDF.assign( PDFLdustloc.begin(), PDFLdustloc.end());
-  pdfcol1.vPDF.assign(  PDFcol1loc.begin(), PDFcol1loc.end());
-  pdfcol2.vPDF.assign(  PDFcol2loc.begin(), PDFcol2loc.end());
-  pdfmref.vPDF.assign(  PDFmrefloc.begin(), PDFmrefloc.end());
+  pdfbayzg.vPDF.assign(PDFzloc.begin(), PDFzloc.end());
+  pdfbayzq.vPDF.assign(PDFzqloc.begin(), PDFzqloc.end());
+  pdfmass.vPDF.assign(PDFmassloc.begin(), PDFmassloc.end());
+  pdfsfr.vPDF.assign(PDFSFRloc.begin(), PDFSFRloc.end());
+  pdfssfr.vPDF.assign(PDFsSFRloc.begin(), PDFsSFRloc.end());
+  pdfage.vPDF.assign(PDFAgeloc.begin(), PDFAgeloc.end());
+  pdfldust.vPDF.assign(PDFLdustloc.begin(), PDFLdustloc.end());
+  pdfcol1.vPDF.assign(PDFcol1loc.begin(), PDFcol1loc.end());
+  pdfcol2.vPDF.assign(PDFcol2loc.begin(), PDFcol2loc.end());
+  pdfmref.vPDF.assign(PDFmrefloc.begin(), PDFmrefloc.end());
 
   // Normalize the PDF
 

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -1048,16 +1048,16 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] /
   // 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] /
   // 11:["BAY_ZG"] / 12:["BAY_ZQ"] Put back 1 dimension array into PDF objects
-  pdfbayzg.vPDF.assign((PDFzloc), (PDFzloc+pdfbayzg.size()));
-  pdfbayzq.vPDF.assign((PDFzqloc), (PDFzqloc+pdfbayzq.size()));
-  pdfmass.vPDF.assign((PDFmassloc), (PDFmassloc+pdfmass.size()));
-  pdfsfr.vPDF.assign((PDFSFRloc), (PDFSFRloc+pdfsfr.size()));
-  pdfssfr.vPDF.assign((PDFsSFRloc), (PDFsSFRloc+pdfssfr.size()));
-  pdfage.vPDF.assign((PDFAgeloc), (PDFAgeloc+pdfage.size()));
-  pdfldust.vPDF.assign((PDFLdustloc), (PDFLdustloc+pdfldust.size()));
-  pdfcol1.vPDF.assign((PDFcol1loc), (PDFcol1loc+pdfcol1.size()));
-  pdfcol2.vPDF.assign((PDFcol2loc), (PDFcol2loc+pdfcol2.size()));
-  pdfmref.vPDF.assign((PDFmrefloc), (PDFmrefloc+pdfmref.size()));
+  pdfbayzg.vPDF.assign((PDFzloc), (PDFzloc + pdfbayzg.size()));
+  pdfbayzq.vPDF.assign((PDFzqloc), (PDFzqloc + pdfbayzq.size()));
+  pdfmass.vPDF.assign((PDFmassloc), (PDFmassloc + pdfmass.size()));
+  pdfsfr.vPDF.assign((PDFSFRloc), (PDFSFRloc + pdfsfr.size()));
+  pdfssfr.vPDF.assign((PDFsSFRloc), (PDFsSFRloc + pdfssfr.size()));
+  pdfage.vPDF.assign((PDFAgeloc), (PDFAgeloc + pdfage.size()));
+  pdfldust.vPDF.assign((PDFLdustloc), (PDFLdustloc + pdfldust.size()));
+  pdfcol1.vPDF.assign((PDFcol1loc), (PDFcol1loc + pdfcol1.size()));
+  pdfcol2.vPDF.assign((PDFcol2loc), (PDFcol2loc + pdfcol2.size()));
+  pdfmref.vPDF.assign((PDFmrefloc), (PDFmrefloc + pdfmref.size()));
 
   // Normalize the PDF
 

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -844,36 +844,17 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] /
   // 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] /
   // 11:["BAY_ZG"] / 12:["BAY_ZQ"]
-  double PDFzloc[pdfmap[11].size()];
-  for (size_t i = 0; i < pdfmap[11].size(); ++i) PDFzloc[i] = 0.0;
-
-  double PDFzqloc[pdfmap[12].size()];
-  for (size_t i = 0; i < pdfmap[12].size(); ++i) PDFzqloc[i] = 0.0;
-
-  double PDFmassloc[pdfmap[0].size()];
-  for (size_t i = 0; i < pdfmap[0].size(); ++i) PDFmassloc[i] = 0.0;
-
-  double PDFSFRloc[pdfmap[1].size()];
-  for (size_t i = 0; i < pdfmap[1].size(); ++i) PDFSFRloc[i] = 0.0;
-
-  double PDFsSFRloc[pdfmap[2].size()];
-  for (size_t i = 0; i < pdfmap[2].size(); ++i) PDFsSFRloc[i] = 0.0;
-
-  double PDFAgeloc[pdfmap[5].size()];
-  for (size_t i = 0; i < pdfmap[5].size(); ++i) PDFAgeloc[i] = 0.0;
-
-  double PDFLdustloc[pdfmap[3].size()];
-  for (size_t i = 0; i < pdfmap[3].size(); ++i) PDFLdustloc[i] = 0.0;
-
-  double PDFcol1loc[pdfmap[6].size()];
-  for (size_t i = 0; i < pdfmap[6].size(); ++i) PDFcol1loc[i] = 0.0;
-
-  double PDFcol2loc[pdfmap[7].size()];
-  for (size_t i = 0; i < pdfmap[7].size(); ++i) PDFcol2loc[i] = 0.0;
-
-  double PDFmrefloc[pdfmap[8].size()];
-  for (size_t i = 0; i < pdfmap[8].size(); ++i) PDFmrefloc[i] = 0.0;
-
+  vector<double> PDFzloc(pdfmap[11].size(), 0.);
+  vector<double> PDFzqloc(pdfmap[12].size(), 0.);
+  vector<double> PDFmassloc(pdfmap[0].size(), 0.);
+  vector<double> PDFSFRloc(pdfmap[1].size(), 0.);
+  vector<double> PDFsSFRloc(pdfmap[2].size(), 0.);
+  vector<double> PDFAgeloc(pdfmap[5].size(), 0.);
+  vector<double> PDFLdustloc(pdfmap[3].size(), 0.);
+  vector<double> PDFcol1loc(pdfmap[6].size(), 0.);
+  vector<double> PDFcol2loc(pdfmap[7].size(), 0.);
+  vector<double> PDFmrefloc(pdfmap[8].size(), 0.);
+  
   // Decide if the uncertainties on the rest-frame colors should be analysed
   bool colAnalysis;
   colAnalysis = ((fltColRF[0] >= 0) && (fltColRF[1] >= 0) &&
@@ -896,15 +877,15 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
 
   // parrallellize over each SED
 #ifdef _OPENMP
+#pragma omp declare reduction(vec_add : vector<double> : transform(omp_out.begin(), omp_out.end(), omp_in.begin(), omp_out.begin(), plus<double>()))
+    //    initializer(omp_priv = decltype(omp_orig)(omp_orig.size()))
   // double start = omp_get_wtime();
 #pragma omp parallel private(pos, col1, col2, rfSED, prob) firstprivate( \
         thread_id, dimzg, number_threads) shared(locChi2, locInd, fulllib)
   {
     // Catch the name of the local thread in the parallelisation
     thread_id = omp_get_thread_num();
-#pragma omp for schedule(static, 10000) reduction(                           \
-        + : PDFzloc, PDFzqloc, PDFmassloc, PDFSFRloc, PDFsSFRloc, PDFAgeloc) \
-    nowait
+#pragma omp for schedule(static, 10000) reduction( vec_add : PDFzloc, PDFzqloc, PDFmassloc, PDFSFRloc, PDFsSFRloc, PDFAgeloc, PDFLdustloc, PDFcol1loc, PDFcol2loc, PDFmrefloc) nowait
 #endif
     // Loop over all SEDs, which is parallelized
     for (size_t i = 0; i < va.size(); i++) {
@@ -1048,16 +1029,16 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"] /
   // 6:["COL1"] / 7:["COL2"] / 8:["MREF"]/ 9:["MIN_ZG"] / 10:["MIN_ZQ"] /
   // 11:["BAY_ZG"] / 12:["BAY_ZQ"] Put back 1 dimension array into PDF objects
-  pdfbayzg.vPDF.assign((PDFzloc), (PDFzloc + pdfbayzg.size()));
-  pdfbayzq.vPDF.assign((PDFzqloc), (PDFzqloc + pdfbayzq.size()));
-  pdfmass.vPDF.assign((PDFmassloc), (PDFmassloc + pdfmass.size()));
-  pdfsfr.vPDF.assign((PDFSFRloc), (PDFSFRloc + pdfsfr.size()));
-  pdfssfr.vPDF.assign((PDFsSFRloc), (PDFsSFRloc + pdfssfr.size()));
-  pdfage.vPDF.assign((PDFAgeloc), (PDFAgeloc + pdfage.size()));
-  pdfldust.vPDF.assign((PDFLdustloc), (PDFLdustloc + pdfldust.size()));
-  pdfcol1.vPDF.assign((PDFcol1loc), (PDFcol1loc + pdfcol1.size()));
-  pdfcol2.vPDF.assign((PDFcol2loc), (PDFcol2loc + pdfcol2.size()));
-  pdfmref.vPDF.assign((PDFmrefloc), (PDFmrefloc + pdfmref.size()));
+  pdfbayzg.vPDF.assign( PDFzloc.begin(), PDFzloc.end() );
+  pdfbayzq.vPDF.assign( PDFzqloc.begin(), PDFzqloc.end() );
+  pdfmass.vPDF.assign(  PDFmassloc.begin(), PDFmassloc.end());
+  pdfsfr.vPDF.assign(   PDFSFRloc.begin(), PDFSFRloc.end());
+  pdfssfr.vPDF.assign(  PDFsSFRloc.begin(), PDFsSFRloc.end());
+  pdfage.vPDF.assign(   PDFAgeloc.begin(), PDFAgeloc.end());
+  pdfldust.vPDF.assign( PDFLdustloc.begin(), PDFLdustloc.end());
+  pdfcol1.vPDF.assign(  PDFcol1loc.begin(), PDFcol1loc.end());
+  pdfcol2.vPDF.assign(  PDFcol2loc.begin(), PDFcol2loc.end());
+  pdfmref.vPDF.assign(  PDFmrefloc.begin(), PDFmrefloc.end());
 
   // Normalize the PDF
 


### PR DESCRIPTION
This is a performance optimization patch that moves complex element lookups out of the hot loops in onesource::generatePDF(), holding references (aliases) to all the required objects through the loops. A variant of this patch, which also included aliases to 1-D vectors (just for debugging), resulted in an improvement of 12% in the total execution time of a 24+ hour estimation run with pz-rail-lephare of the LSST DP0.2 dataset (from 28 hours to 25 hours).

The detailed changes in this patch are the following:

- Remove unordered map lookups from the main onesource::generatePDF() loop.
- Move the indirect access of 2 out of the 3 vector dimensions outside a nested loop in onesource::generatePDF().
- Replace an explicit loop by an implicit one to copy temporary vectors to the final ones.

<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->



## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
