### PR TITLE
Change the function validLib to improve the code efficiency.

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Collect C++ coverage
       run: |
+        geninfo --ignore-errors gcov build
         lcov --output-file coverage.cpp --capture --directory build
         lcov --output-file coverage.cpp --extract coverage.cpp $PWD/src/"*"
         cat coverage.lcov coverage.cpp > coverage.txt

--- a/docs/notebooks/Testing_fit_of_one_object_of_the_catalogue.ipynb
+++ b/docs/notebooks/Testing_fit_of_one_object_of_the_catalogue.ipynb
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "valid = src.validLib(photz.fullLib, zfix, src.zs)"
+    "valid = src.validLib(photz.zLib, zfix)"
    ]
   },
   {

--- a/docs/notebooks/Testing_fit_of_one_object_of_the_catalogue.ipynb
+++ b/docs/notebooks/Testing_fit_of_one_object_of_the_catalogue.ipynb
@@ -337,7 +337,7 @@
     "src.uncertaintiesMin()\n",
     "src.uncertaintiesBay()\n",
     "src.secondpeak(photz.fullLib, 0.3, 0.02)\n",
-    "src.considered_red(zfix, false)\n",
+    "src.considered_red(zfix, False)\n",
     "src.interp_lib(photz.fullLib, nfilt, lcdm)"
    ]
   },

--- a/docs/notebooks/Testing_fit_of_one_object_of_the_catalogue.ipynb
+++ b/docs/notebooks/Testing_fit_of_one_object_of_the_catalogue.ipynb
@@ -337,7 +337,7 @@
     "src.uncertaintiesMin()\n",
     "src.uncertaintiesBay()\n",
     "src.secondpeak(photz.fullLib, 0.3, 0.02)\n",
-    "src.considered_red(zfix, \"BEST\")\n",
+    "src.considered_red(zfix, false)\n",
     "src.interp_lib(photz.fullLib, nfilt, lcdm)"
    ]
   },

--- a/src/lib/_bindings.cc
+++ b/src/lib/_bindings.cc
@@ -59,7 +59,8 @@ PYBIND11_MODULE(_lephare, mod) {
       .def("time", &cosmo::time, py::arg("z"))
       .def("distMod", py::vectorize(&cosmo::distMod))
       .def("distMet", py::vectorize(&cosmo::distMet))
-      .def("time", py::vectorize(&cosmo::time));
+      .def("time", py::vectorize(&cosmo::time))
+      .def("flux_rescaling", &cosmo::flux_rescaling);
   mod.def("zgrid", &zgrid);
   mod.def("indexz", &indexz);
 
@@ -272,6 +273,8 @@ PYBIND11_MODULE(_lephare, mod) {
       .def_readonly("fluxIR", &PhotoZ::fluxIR)
       .def_readonly("imagm", &PhotoZ::imagm)
       .def_readonly("fullLib", &PhotoZ::fullLib)
+      .def_readonly("zLib", &PhotoZ::zLib)
+      .def_readonly("flux", &PhotoZ::flux)
       .def_readonly("fullLibIR", &PhotoZ::fullLibIR)
       .def_readonly("allFilters", &PhotoZ::allFilters)
       .def_readonly("gridz", &PhotoZ::gridz)

--- a/src/lib/cosmology.cpp
+++ b/src/lib/cosmology.cpp
@@ -115,6 +115,12 @@ double cosmo::time(double z) const {
   return timy;
 }
 
+double cosmo::flux_rescaling(double z, double target_z) const {
+  double current_dm = distMod(z);
+  double target_dm = distMod(target_z);
+  return POW10D(0.4 * (target_dm - current_dm));
+}
+
 // Two possible grid in redshift : linear or in (1+z)
 // Possible now to define a minimum redshift to be considered
 vector<double> zgrid(int gridType, double dz, double zmin, double &zmax) {

--- a/src/lib/cosmology.h
+++ b/src/lib/cosmology.h
@@ -45,6 +45,20 @@ class cosmo {
     output << c.h0 << "," << c.om0 << "," << c.l0;
     return output;
   }
+
+  //! Return the scaling factor that brings a flux from one value to another,
+  //! based only on a change of redshift.
+  /*!
+    \param z Current redshift
+    \param z_t Target redshift
+
+    \return flux scale factor corresponding to a distance change
+    from \f$z\f$ to \f$z_t\f$ :
+    \f$ scale = 10^{0.4(dm(z_t)-dm(z))}\f$
+    where \f$dm\f$ is the distance modulus for a given redshift and is obtained
+    calling the function cosmo::distMod.
+  */
+  double flux_rescaling(double z, double z_t) const;
 };
 
 vector<double> zgrid(int gridType, double dz, double zmin, double &zmax);

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -410,7 +410,7 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
     // Catch the name of the local thread in the parrallelisation
     thread_id = omp_get_thread_num();
 #endif
-   
+
     // Compute normalisation and chi2
 #pragma omp for schedule(static, 10000)
     for (size_t v = 0; v < va.size(); v++) {
@@ -516,7 +516,7 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
   return;
 }
 
- 
+
 void onesource::compute_best_fit_physical_quantities(vector<SED *> &fulllib) {
   // Best fit values for GAL physical parameters
   if (indmin[0] >= 0 && dmmin[0] > 0) {

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -44,10 +44,10 @@ void onesource::readsource(const string &identifier, const vector<double> vals,
 /*
  Fixed the redshift considered for abs mag, etc depending on the option
 */
-void onesource::considered_red(const bool zfix, const string methz) {
+void onesource::considered_red(const bool zfix, const bool methz) {
   // if zfix is not fixed
   if (!zfix) {
-    if (methz[0] == 'M' || methz[0] == 'm') {
+    if (methz) {
       // if considered redshift is the median of the PDF
       consiz = zgmed[0];
     } else {

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -269,22 +269,22 @@ vector<size_t> onesource::validLib(const vector<double> &zLib,
   if (zfix) {
     for (size_t i = 0; i < zLib.size(); i++) {
       // Keep only the index corresponding to the closest redshift in the grid
-      if (abs(zLib[i]-closest_red)<1.e-10) val.push_back(i);
+      if (abs(zLib[i] - closest_red) < 1.e-10) val.push_back(i);
     }
   } else {
     // If not fixed redshift, use everything
     val.resize(zLib.size());
-    #ifdef _OPENMP
-    #pragma omp parallel 
+#ifdef _OPENMP
+#pragma omp parallel 
     {
-    #endif
-     #pragma omp for schedule(static, 10000)
+#endif
+#pragma omp for schedule(static, 10000)
      for (size_t i = 0; i < zLib.size(); i++) {
        val[i]=i;
      }
-    #ifdef _OPENMP
+#ifdef _OPENMP
     }
-    #endif
+#endif
   }
 
   return val;
@@ -414,7 +414,7 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
 
 #ifdef _OPENMP
   // double start = omp_get_wtime();
-#pragma omp parallel shared(fulllib)				\
+#pragma omp parallel shared(fulllib)			        	\
     firstprivate(s2n, invsab, invsabSq, abinvsabSq, imagm, nbul, busul, \
                      priorLib, number_threads, thread_id)
   {
@@ -430,7 +430,7 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
 
       // Measurement of scaling factor dm only with (fobs>flim), dchi2/ddm = 0
       double avmago = 0., avmagt = 0.;
-      double dmloc=-999.;
+      double dmloc = -999.;
       for (size_t k = 0; k < imagm; k++) {
         double fluxin = flux[i][k];
         avmago += fluxin * abinvsabSq[k];

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -280,7 +280,7 @@ vector<size_t> onesource::validLib(const vector<double> &zLib,
 #endif
 #pragma omp for schedule(static, 10000)
       for (size_t i = 0; i < zLib.size(); i++) {
-        val[i]=i;
+        val[i] = i;
       }
 #ifdef _OPENMP
     }

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -262,8 +262,6 @@ void onesource::adapt_mag(vector<double> a0, vector<double> a1) {
 */
 vector<size_t> onesource::validLib(const vector<double> &zLib,
                                    const bool &zfix) {
-
-
   vector<size_t> val;
   // Condition with the redshift set ZFIX YES
   if (zfix) {
@@ -528,7 +526,6 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
   return;
 }
 
-
 void onesource::compute_best_fit_physical_quantities(vector<SED *> &fulllib) {
   // Best fit values for GAL physical parameters
   if (indmin[0] >= 0 && dmmin[0] > 0) {
@@ -555,9 +552,6 @@ void onesource::compute_best_fit_physical_quantities(vector<SED *> &fulllib) {
   }
   return;
 }
-
-
-
 
 /*
   Use prior info on N(z) as a function of magnitude (Iband) and of the type.
@@ -660,7 +654,6 @@ void onesource::rm_discrepant(vector<SED *> &fulllib,
                               const vector<vector<double>> &flux,
                               const vector<size_t> &va, const double funz0,
                               const array<int, 2> bp, double thresholdChi2) {
-
   size_t imagm = busnorma.size();
   double newmin, improvedChi2;
   // Start with the best chi2 among the libraries

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -275,13 +275,13 @@ vector<size_t> onesource::validLib(const vector<double> &zLib,
     // If not fixed redshift, use everything
     val.resize(zLib.size());
 #ifdef _OPENMP
-#pragma omp parallel 
+#pragma omp parallel
     {
 #endif
 #pragma omp for schedule(static, 10000)
-     for (size_t i = 0; i < zLib.size(); i++) {
-       val[i]=i;
-     }
+      for (size_t i = 0; i < zLib.size(); i++) {
+        val[i]=i;
+      }
 #ifdef _OPENMP
     }
 #endif
@@ -414,7 +414,7 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
 
 #ifdef _OPENMP
   // double start = omp_get_wtime();
-#pragma omp parallel shared(fulllib)			        	\
+#pragma omp parallel shared(fulllib)                                    \
     firstprivate(s2n, invsab, invsabSq, abinvsabSq, imagm, nbul, busul, \
                      priorLib, number_threads, thread_id)
   {

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -735,7 +735,7 @@ void onesource::fitIR(vector<SED *> &fulllibIR,
 #pragma omp for schedule(static, 10000)
     // Loop over all SEDs from the library
     for (size_t i = 0; i < fulllibIR.size(); i++) {
-      if (fulllibIR[i]->red == closest_red) {
+      if (abs(fulllibIR[i]->red - closest_red) < 1.e-10) {
         // Difference between the distance modulus at the redshift of the
         // library and the finel one considered
         double dmcor;

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -267,12 +267,9 @@ vector<size_t> onesource::validLib(const vector<double> &zLib,
   vector<size_t> val;
   // Condition with the redshift set ZFIX YES
   if (zfix) {
-    vector<size_t> val;
     for (size_t i = 0; i < zLib.size(); i++) {
-      // closest_red is one of the zgrid, and so are the zLib[i],
-      // so the strict equality, though fragile for floating points,
-      // should be ok.
-      if (zLib[i] == closest_red) val.push_back(i);
+      // Keep only the index corresponding to the closest redshift in the grid
+      if (abs(zLib[i]-closest_red)<1.e-10) val.push_back(i);
     }
   } else {
     // If not fixed redshift, use everything

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -260,17 +260,17 @@ void onesource::adapt_mag(vector<double> a0, vector<double> a1) {
 /*
  RETURN THE INDEX OF THE LIBRARY TO BE CONSIDERED (MAINLY ZFIX CASE)
 */
-vector<size_t> onesource::validLib(vector<SED *> &thelib, const bool &zfix,
+vector<size_t> onesource::validLib(const vector<double> &zLib, const bool &zfix,
                                    const double &consideredZ) {
   vector<size_t> val;
   // Condition with the redshift set ZFIX YES
   if (zfix) {
-    for (size_t i = 0; i < thelib.size(); i++) {
-      if ((thelib[i])->red == closest_red) val.push_back(i);
+    for (size_t i = 0; i < zLib.size(); i++) {
+      if (zLib[i] == closest_red) val.push_back(i);
     }
   } else {
     // If not fixed redshift, use everything
-    for (size_t i = 0; i < thelib.size(); i++) val.push_back(i);
+    for (size_t i = 0; i < zLib.size(); i++) val.push_back(i);
   }
 
   return val;

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -262,9 +262,12 @@ void onesource::adapt_mag(vector<double> a0, vector<double> a1) {
 */
 vector<size_t> onesource::validLib(const vector<double> &zLib,
                                    const bool &zfix) {
+
+
   vector<size_t> val;
   // Condition with the redshift set ZFIX YES
   if (zfix) {
+    vector<size_t> val;
     for (size_t i = 0; i < zLib.size(); i++) {
       // closest_red is one of the zgrid, and so are the zLib[i],
       // so the strict equality, though fragile for floating points,
@@ -273,7 +276,18 @@ vector<size_t> onesource::validLib(const vector<double> &zLib,
     }
   } else {
     // If not fixed redshift, use everything
-    for (size_t i = 0; i < zLib.size(); i++) val.push_back(i);
+    val.resize(zLib.size());
+    #ifdef _OPENMP
+    #pragma omp parallel 
+    {
+    #endif
+     #pragma omp for schedule(static, 10000)
+     for (size_t i = 0; i < zLib.size(); i++) {
+       val[i]=i;
+     }
+    #ifdef _OPENMP
+    }
+    #endif
   }
 
   return val;

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -260,12 +260,15 @@ void onesource::adapt_mag(vector<double> a0, vector<double> a1) {
 /*
  RETURN THE INDEX OF THE LIBRARY TO BE CONSIDERED (MAINLY ZFIX CASE)
 */
-vector<size_t> onesource::validLib(const vector<double> &zLib, const bool &zfix,
-                                   const double &consideredZ) {
+vector<size_t> onesource::validLib(const vector<double> &zLib,
+                                   const bool &zfix) {
   vector<size_t> val;
   // Condition with the redshift set ZFIX YES
   if (zfix) {
     for (size_t i = 0; i < zLib.size(); i++) {
+      // closest_red is one of the zgrid, and so are the zLib[i],
+      // so the strict equality, though fragile for floating points,
+      // should be ok.
       if (zLib[i] == closest_red) val.push_back(i);
     }
   } else {
@@ -1543,31 +1546,24 @@ void onesource::interp_lib(vector<SED *> &fulllib, const int imagm,
 /*
  REDSHIFT INTERPOLATION  if  ZINTP=true
 */
-void onesource::interp(const bool zfix, const bool zintp, cosmo lcdm) {
-  // keep distance modulus before interpolation
-  double distGbef = lcdm.distMod(zmin[0]);
-  double distQbef = lcdm.distMod(zmin[1]);
-
-  // If zfix=yes, use the spec-z as best value
+void onesource::interp(const bool zfix, const bool zintp, const cosmo &lcdm) {
   if (zfix) {
-    // Modify the zmin for the galaxy
+    dmmin[0] *= lcdm.flux_rescaling(zmin[0], zs);
     zmin[0] = zs;
+    dmmin[1] *= lcdm.flux_rescaling(zmin[1], zs);
     zmin[1] = zs;
-  } else {
-    // If zfix=no but an interpolation is required
-    if (zintp) {
-      // The new zmin is coming from the PDF, the one with the minimum chi2
-      zmin[0] = pdfmap[9].int_parab();   // Galaxies
-      zmin[1] = pdfmap[10].int_parab();  // AGN
-    }
+    return;
   }
 
-  // Need to rescale the normalisation accoring to the new redshift
-  // distance modulus after interpolation
-  double distGaft = lcdm.distMod(zmin[0]);
-  double distQaft = lcdm.distMod(zmin[1]);
-  dmmin[0] = dmmin[0] * pow(10., (0.4 * (distGaft - distGbef)));
-  dmmin[1] = dmmin[1] * pow(10., (0.4 * (distQaft - distQbef)));
+  if (zintp) {
+    double target_z_gal = pdfmap[9].int_parab();
+    double target_z_qso = pdfmap[10].int_parab();
+    dmmin[0] *= lcdm.flux_rescaling(zmin[0], target_z_gal);
+    zmin[0] = target_z_gal;
+    dmmin[1] *= lcdm.flux_rescaling(zmin[1], target_z_qso);
+    zmin[1] = target_z_qso;
+    return;
+  }
 }
 
 /*

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -18,6 +18,7 @@
 #include "flt.h"  // filter class
 #include "globals.h"
 #include "opa.h"
+#include <omp.h>
 
 using namespace std;
 
@@ -100,6 +101,7 @@ class onesource {
     imasminIR = -99;
     nbused = 0;
     pos = 0;
+    
   }
 
   // Need to initialize the PDF in the constructor after the ":"

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -18,7 +18,6 @@
 #include "flt.h"  // filter class
 #include "globals.h"
 #include "opa.h"
-#include <omp.h>
 
 using namespace std;
 
@@ -101,7 +100,6 @@ class onesource {
     imasminIR = -99;
     nbused = 0;
     pos = 0;
-    
   }
 
   // Need to initialize the PDF in the constructor after the ":"

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -59,7 +59,10 @@ class onesource {
   vector<int> busnorma, busul, busfir, bscfir, absfilt;
   string spec, str_inp;
   int pos, nbused, nbul, nbusIR, indminSec, indminIR;
-  double zs, dm, consiz, closest_red;
+  double zs, dm, consiz;
+  /// The closest redshift to a true/spectro redshift, when provided with
+  /// the source, in the grid of redshift used for the fit.
+  double closest_red;
   array<double, 3> zmin, chimin, dmmin;
   array<int, 3> indmin, imasmin;
   double zminIR, chiminIR, dmminIR, imasminIR;
@@ -186,8 +189,19 @@ class onesource {
   void convertFlux(const string &catmag, const vector<flt> allFilters);
   void rescale_flux_errors(const vector<double> min_err,
                            const vector<double> fac_err);
-  vector<size_t> validLib(const vector<double> &zLib, const bool &zfix,
-                          const double &consideredZ);
+
+  //! Return the indexes over zlib vector on which to run the fit
+  /*!
+    \param zlib The vector of redshifts of each template in the full library, in
+    the same order \param zfix If true only take indexes of the templates whose
+    redshifts are the closest to the true/spectro z. onesource::closest_red
+    needs to have been set, else the the return vector will contain all the
+    indexes, as closest_red is initialized to a negative unphysical value.
+
+    \return Vector of indexes to be used on the full library.
+   */
+  vector<size_t> validLib(const vector<double> &zLib, const bool &zfix);
+
   void fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
            const vector<size_t> &valid, const double &funz0,
            const array<int, 2> &bp);
@@ -207,7 +221,20 @@ class onesource {
                  unordered_map<string, ofstream> &stpdz);
   void convertMag();
   void keepOri();
-  void interp(const bool zfix, const bool zintp, cosmo lcdm);
+
+  //! Update the solution of the fit based on execution flags
+  /*!
+    \param zfix bool that sets whether to set solution to a given redshift,
+    typically a true or spectroscopic redshift \param zintp bool that sets
+    whether to improve the determination of the minimum on the chi2 curve, using
+    the method PDF::int_parabL
+
+    \param[out] zmin and dmmin are reevaluated, for types GAL and QSO
+
+    Note that zfix and zintp are not supposed to both be set. In case it
+    happens, zintp is discarded here.
+   */
+  void interp(const bool zfix, const bool zintp, const cosmo &lcdm);
   void uncertaintiesMin();
   void uncertaintiesBay();
   void secondpeak(vector<SED *> &fulllib, const double dz_win,

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -180,7 +180,7 @@ class onesource {
   void readsource(const string &identifier, const vector<double> vals,
                   const vector<double> err_vals, const long context,
                   const double z_spec, const string additional_input);
-  void considered_red(const bool zfix, const string methz);
+  void considered_red(const bool zfix, const bool methz);
   void setPriors(const array<double, 2> magabsB,
                  const array<double, 2> magabsF);
   void fltUsed(const long gbcont, const long contforb, const int imagm);

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -186,7 +186,7 @@ class onesource {
   void convertFlux(const string &catmag, const vector<flt> allFilters);
   void rescale_flux_errors(const vector<double> min_err,
                            const vector<double> fac_err);
-  vector<size_t> validLib(vector<SED *> &fulllib, const bool &zfix,
+  vector<size_t> validLib(const vector<double> &zLib, const bool &zfix,
                           const double &consideredZ);
   void fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
            const vector<size_t> &valid, const double &funz0,

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -414,7 +414,7 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
   if (filtNameAdd != "none" && filtNameAdd != "NONE") {
     allFiltersAdd = read_doc_filters(filtNameAdd);
   }
-  
+
   /* Create a 2D array with the predicted flux.
   Done to improve the performance in the fit*/
   flux.resize(fullLib.size(), vector<double>(imagm, 0.));
@@ -1606,11 +1606,11 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     oneObj->fit(fullLib, flux, valid, funz0, bp);
     // Try to remove some bands to improve the chi2, only as long as the chi2 is
     // above a threshold
-     oneObj->rm_discrepant(fullLib, flux, valid, funz0, bp, thresholdChi2);
+    oneObj->rm_discrepant(fullLib, flux, valid, funz0, bp, thresholdChi2);
     // Generate the marginalized PDF (z+physical parameters) from the chi2
     // stored in each SED
     oneObj->generatePDF(fullLib, valid, fltColRF, fltREF, zfix);
-   // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
+    // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
     // ZFIX YES  (only gal for the moment)
     oneObj->interp(zfix, zintp, lcdm);
     // Uncertainties from the minimum chi2 + delta chi2
@@ -1658,7 +1658,7 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     }
     // compute physical quantities for the best fit GAL solution
     oneObj->compute_best_fit_physical_quantities(fullLib);
-   
+
   }
   return;
 }

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -1610,15 +1610,13 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     // Try to remove some bands to improve the chi2, only as long as the chi2 is
     // above a threshold
     oneObj->rm_discrepant(fullLib, flux, valid, funz0, bp, thresholdChi2);
-    // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
-    // ZFIX YES  (only gal for the moment)
-    if (zfix || zintp) {
-      oneObj->interp(zfix, zintp, lcdm);
-    }
-    // Generate the marginalized PDF (z+physical parameters) from the chi2
+     // Generate the marginalized PDF (z+physical parameters) from the chi2
     // stored in each SED
     oneObj->generatePDF(fullLib, valid, fltColRF, fltREF, zfix);
-    // Uncertainties from the minimum chi2 + delta chi2
+    // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
+    // ZFIX YES  (only gal for the moment)
+    if (zfix || zintp)  oneObj->interp(zfix, zintp, lcdm);
+   // Uncertainties from the minimum chi2 + delta chi2
     oneObj->uncertaintiesMin();
     // Uncertainties from the bayesian method, centered on the median
     oneObj->uncertaintiesBay();

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -418,6 +418,7 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
   /* Create a 2D array with the predicted flux.
   Done to improve the performance in the fit*/
   flux.resize(fullLib.size(), vector<double>(imagm, 0.));
+  zLib.resize(fullLib.size(), -99.);
   fluxIR.resize(fullLibIR.size(), vector<double>(imagm, 0.));
 // Convert the magnitude library in flux
 #ifdef _OPENMP
@@ -429,6 +430,8 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
     for (size_t k = 0; k < allFilters.size(); k++) {
       flux[i][k] = pow(10., -0.4 * (fullLib[i]->mag[k] + 48.6));
     }
+    // create a vector with the redshift of the library
+    zLib[i] = fullLib[i]->red;
   }
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
@@ -1020,7 +1023,7 @@ std::tuple<vector<double>, vector<double>> PhotoZ::run_autoadapt(
         oneObj->closest_red = gridz[indexz(oneObj->zs, gridz)];
         // Select the valid index of the library in case of ZFIX=YES to save
         // computational time
-        valid = oneObj->validLib(fullLib, zfix, oneObj->zs);
+        valid = oneObj->validLib(zLib, zfix, oneObj->zs);
         // Fit the source at the spec-z value
         oneObj->fit(fullLib, flux, valid, funz0, bp);
         // Interpolation of the predicted magnitudes, scaling at zs, checking
@@ -1598,7 +1601,7 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     oneObj->setPriors(magabsB, magabsF);
     // Select the valid index of the library in case of ZFIX=YES to save
     // computational time
-    valid = oneObj->validLib(fullLib, zfix, oneObj->zs);
+    valid = oneObj->validLib(zLib, zfix, oneObj->zs);
     // Core of the program: compute the chi2
     oneObj->fit(fullLib, flux, valid, funz0, bp);
     // Try to remove some bands to improve the chi2, only as long as the chi2 is

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -414,7 +414,7 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
   if (filtNameAdd != "none" && filtNameAdd != "NONE") {
     allFiltersAdd = read_doc_filters(filtNameAdd);
   }
-
+  
   /* Create a 2D array with the predicted flux.
   Done to improve the performance in the fit*/
   flux.resize(fullLib.size(), vector<double>(imagm, 0.));
@@ -1606,11 +1606,11 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     oneObj->fit(fullLib, flux, valid, funz0, bp);
     // Try to remove some bands to improve the chi2, only as long as the chi2 is
     // above a threshold
-    oneObj->rm_discrepant(fullLib, flux, valid, funz0, bp, thresholdChi2);
+     oneObj->rm_discrepant(fullLib, flux, valid, funz0, bp, thresholdChi2);
     // Generate the marginalized PDF (z+physical parameters) from the chi2
     // stored in each SED
     oneObj->generatePDF(fullLib, valid, fltColRF, fltREF, zfix);
-    // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
+   // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
     // ZFIX YES  (only gal for the moment)
     oneObj->interp(zfix, zintp, lcdm);
     // Uncertainties from the minimum chi2 + delta chi2
@@ -1658,6 +1658,7 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     }
     // compute physical quantities for the best fit GAL solution
     oneObj->compute_best_fit_physical_quantities(fullLib);
+   
   }
   return;
 }

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -1606,17 +1606,17 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     // computational time
     valid = oneObj->validLib(zLib, zfix);
     // Core of the program: compute the chi2
-     oneObj->fit(fullLib, flux, valid, funz0, bp);
+    oneObj->fit(fullLib, flux, valid, funz0, bp);
     // Try to remove some bands to improve the chi2, only as long as the chi2 is
     // above a threshold
     oneObj->rm_discrepant(fullLib, flux, valid, funz0, bp, thresholdChi2);
-     // Generate the marginalized PDF (z+physical parameters) from the chi2
+    // Generate the marginalized PDF (z+physical parameters) from the chi2
     // stored in each SED
-     oneObj->generatePDF(fullLib, valid, fltColRF, fltREF, zfix);
+    oneObj->generatePDF(fullLib, valid, fltColRF, fltREF, zfix);
     // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
     // ZFIX YES  (only gal for the moment)
-    if (zfix || zintp)  oneObj->interp(zfix, zintp, lcdm);
-   // Uncertainties from the minimum chi2 + delta chi2
+    if (zfix || zintp) oneObj->interp(zfix, zintp, lcdm);
+    // Uncertainties from the minimum chi2 + delta chi2
     oneObj->uncertaintiesMin();
     // Uncertainties from the bayesian method, centered on the median
     oneObj->uncertaintiesBay();

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -1606,13 +1606,13 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     // computational time
     valid = oneObj->validLib(zLib, zfix);
     // Core of the program: compute the chi2
-    oneObj->fit(fullLib, flux, valid, funz0, bp);
+     oneObj->fit(fullLib, flux, valid, funz0, bp);
     // Try to remove some bands to improve the chi2, only as long as the chi2 is
     // above a threshold
     oneObj->rm_discrepant(fullLib, flux, valid, funz0, bp, thresholdChi2);
      // Generate the marginalized PDF (z+physical parameters) from the chi2
     // stored in each SED
-    oneObj->generatePDF(fullLib, valid, fltColRF, fltREF, zfix);
+     oneObj->generatePDF(fullLib, valid, fltColRF, fltREF, zfix);
     // Interpolation of Z_BEST and ZQ_BEST (zmin) via Chi2 curves, put z-spec if
     // ZFIX YES  (only gal for the moment)
     if (zfix || zintp)  oneObj->interp(zfix, zintp, lcdm);
@@ -1661,7 +1661,6 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     }
     // compute physical quantities for the best fit GAL solution
     oneObj->compute_best_fit_physical_quantities(fullLib);
-
   }
   return;
 }

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -1634,6 +1634,8 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     if (methz && (!zfix)) {
       oneObj->chimin[0] = 1.e9;
       oneObj->closest_red = gridz[indexz(oneObj->zgmed[0], gridz)];
+      // Select the valid index of the library corresponding to zgmed
+      valid = oneObj->validLib(zLib, true);
       oneObj->fit(fullLib, flux, valid, funz0, bp);
     }
     // Interpolation at the new redshift  (only gal for the moment)

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -182,9 +182,10 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
   // Z_INTERP redshift interpolation between library Z-STEP
   zintp = key_analysed["Z_INTERP"].split_bool("NO", 1)[0];
 
-  // Z_METHOD compute the absolute magnitude at a given redshift solution ML or
+  // Z_METHOD compute the absolute magnitude at a given redshift solution MED or
   // BEST - BEST by default
-  methz = ((key_analysed["Z_METHOD"]).split_string("BEST", 1))[0];
+  string tmp = ((key_analysed["Z_METHOD"]).split_string("BEST", 1))[0];
+  methz = (tmp[0] == 'M' || tmp[0] == 'm') ? true : false;
 
   /* search for secondary solution  */
 
@@ -322,7 +323,8 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
   outputHeader += "# NZ_PRIOR               : " + to_string(bp[0]) + ' ' +
                   to_string(bp[1]) + '\n';
   outputHeader += "# Z_INTERP               : " + bool2string(zintp) + '\n';
-  outputHeader += "# Z_METHOD               : " + methz + '\n';
+  outputHeader +=
+      "# Z_METHOD               : " + string(methz ? "MED" : "BEST") + '\n';
   outputHeader += "# PROB_INTZ              : ";
   for (int k = 0; k < npdz; k++) {
     outputHeader += to_string(int_pdz[k]) + ' ';
@@ -1629,7 +1631,7 @@ void PhotoZ::run_photoz(vector<onesource *> sources, const vector<double> &a0,
     oneObj->considered_red(zfix, methz);
     // If use the median of the PDF for the abs mag, etc, need to redo the fit
     // Need to redo the fit to get the right scaling. It would change ZMIN, etc
-    if ((methz[0] == 'M' || methz[0] == 'm') && (!zfix)) {
+    if (methz && (!zfix)) {
       oneObj->chimin[0] = 1.e9;
       oneObj->closest_red = gridz[indexz(oneObj->zgmed[0], gridz)];
       oneObj->fit(fullLib, flux, valid, funz0, bp);

--- a/src/lib/photoz_lib.h
+++ b/src/lib/photoz_lib.h
@@ -22,8 +22,15 @@ class PhotoZ {
   double fir_lmin, fir_cont, fir_scale;
   bool verbose;
   array<double, 2> magabsB, magabsF, zrange, ebvrange;
-  bool outchi, zintp, zfix;
-  string cat, methz, typm, catmag, cattyp, zmulti, outf, outsp, outpdz, outpdm;
+  bool outchi,  /// Whether or not to output th chi2 values in ascii
+      zintp,    /// Whether or not to interpolate the z solution from the grid
+                /// result
+      zfix,     /// Whether or not to run with a fixed redshift, typically the
+                /// true/spectro z
+      methz;    /// If true, set z to the MEDIAN solution rather than the BEST
+                /// solution, when computing physical parameters.
+
+  string cat, typm, catmag, cattyp, zmulti, outf, outsp, outpdz, outpdm;
   vector<double> shifts0, shifts1, min_err, fac_err, int_pdz, zbmin, zbmax;
   vector<flt> allFiltersAdd;
   vector<vector<int>> goodFlt;

--- a/src/lib/photoz_lib.h
+++ b/src/lib/photoz_lib.h
@@ -33,10 +33,10 @@ class PhotoZ {
   vector<int> bapp, bappOp, pdz_fabs, emMod;
   cosmo lcdm;
   vector<size_t> valid;
-  vector<double> zLib;
 
  public:
   vector<vector<double>> flux, fluxIR;
+  vector<double> zLib;
   vector<SED *> fullLib, fullLibIR, lightLib;
   vector<flt> allFilters;
   vector<double> gridz;

--- a/src/lib/photoz_lib.h
+++ b/src/lib/photoz_lib.h
@@ -33,6 +33,7 @@ class PhotoZ {
   vector<int> bapp, bappOp, pdz_fabs, emMod;
   cosmo lcdm;
   vector<size_t> valid;
+  vector<double> zLib;
 
  public:
   vector<vector<double>> flux, fluxIR;

--- a/tests/lephare/test_cosmology.py
+++ b/tests/lephare/test_cosmology.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from lephare import cosmo, indexz, zgrid
 
 
@@ -58,3 +59,13 @@ def test_cosmology_indexz():
     assert indexz(2.5, grid) == 2
     # test value smaller and close to a grid value
     assert indexz(2.9, grid) == 2
+
+
+def test_flux_rescaling():
+    c = cosmo()
+    z1 = 0.1
+    dm1 = c.distMod(z1)
+    z2 = 0.2
+    dm2 = c.distMod(z2)
+    assert c.flux_rescaling(z1, z1) == 1.0
+    assert c.flux_rescaling(z1, z2) == pytest.approx(np.power(10, 0.4 * (dm2 - dm1)))

--- a/tests/lephare/test_onesource.py
+++ b/tests/lephare/test_onesource.py
@@ -43,5 +43,15 @@ def test_onesource_set_priors():
 def test_validlib():
     s = onesource()
     s.closest_red = 0.15
-    assert s.validLib([0, 0.05, 0.15, 0.2, 0, 0.05, 0.15, 0.2, ], True) == [2,6]
+    assert s.validLib([
+        0,
+        0.05,
+        0.15,
+        0.2,
+        0,
+        0.05,
+        0.15,
+        0.2,
+    ], True,
+    ) == [2,6]
     assert s.validLib([0, 0.05, 0.15, 0.2], False) == [0, 1, 2, 3]

--- a/tests/lephare/test_onesource.py
+++ b/tests/lephare/test_onesource.py
@@ -43,7 +43,5 @@ def test_onesource_set_priors():
 def test_validlib():
     s = onesource()
     s.closest_red = 0.15
-    assert s.validLib([0, 0.05, 0.15, 0.2], True) == [
-        2,
-    ]
+    assert s.validLib([0, 0.05, 0.15, 0.2, 0, 0.05, 0.15, 0.2, ], True) == [2,6]
     assert s.validLib([0, 0.05, 0.15, 0.2], False) == [0, 1, 2, 3]

--- a/tests/lephare/test_onesource.py
+++ b/tests/lephare/test_onesource.py
@@ -43,15 +43,5 @@ def test_onesource_set_priors():
 def test_validlib():
     s = onesource()
     s.closest_red = 0.15
-    assert s.validLib([
-        0,
-        0.05,
-        0.15,
-        0.2,
-        0,
-        0.05,
-        0.15,
-        0.2,
-    ], True,
-    ) == [2,6]
-    assert s.validLib([0, 0.05, 0.15, 0.2], False) == [0, 1, 2, 3]
+    assert s.validLib( [0, 0.05, 0.15, 0.2, 0, 0.05, 0.15, 0.2], True) == [2, 6]
+    assert s.validLib( [0, 0.05, 0.15, 0.2], False) == [0, 1, 2, 3]

--- a/tests/lephare/test_onesource.py
+++ b/tests/lephare/test_onesource.py
@@ -38,3 +38,12 @@ def test_onesource_set_priors():
     src = onesource()
     src.setPriors([0.0, 1000.0], [0, 1000])
     assert np.array_equal(src.priorLib, [0.0, 0.0, 1000.0, 1000.0])
+
+
+def test_validlib():
+    s = onesource()
+    s.closest_red = 0.15
+    assert s.validLib([0, 0.05, 0.15, 0.2], True) == [
+        2,
+    ]
+    assert s.validLib([0, 0.05, 0.15, 0.2], False) == [0, 1, 2, 3]

--- a/tests/lephare/test_onesource.py
+++ b/tests/lephare/test_onesource.py
@@ -43,5 +43,5 @@ def test_onesource_set_priors():
 def test_validlib():
     s = onesource()
     s.closest_red = 0.15
-    assert s.validLib( [0, 0.05, 0.15, 0.2, 0, 0.05, 0.15, 0.2], True) == [2, 6]
-    assert s.validLib( [0, 0.05, 0.15, 0.2], False) == [0, 1, 2, 3]
+    assert s.validLib([0, 0.05, 0.15, 0.2, 0, 0.05, 0.15, 0.2], True) == [2, 6]
+    assert s.validLib([0, 0.05, 0.15, 0.2], False) == [0, 1, 2, 3]

--- a/tests/lephare/test_prepare.py
+++ b/tests/lephare/test_prepare.py
@@ -30,8 +30,9 @@ def test_load_sed_list(test_data_dir):
     assert os.path.exists(os.path.join(test_dir, "../data/sed/QSO/ONE_SED/ONE_SED.list"))
     # Check the sed is there
     assert os.path.exists(os.path.join(test_dir, "../data/sed/QSO/ONE_SED/o5v.sed.ext"))
-    # Clear the copied folder
+    # Clear the copied folders
     shutil.rmtree(os.path.join(test_dir, "../tmp/seds"))
+    shutil.rmtree(os.path.join(test_dir, "../data/sed/QSO/ONE_SED"))
 
 
 def test_all_types_to_keymap():

--- a/tests/lephare/test_process.py
+++ b/tests/lephare/test_process.py
@@ -26,7 +26,7 @@ def test_process(test_data_dir: str):
             reduced_cols.append(c)
         elif "IB679" in c:
             reduced_cols.append(c)
-    output, photozlist = lp.process(config, input[reduced_cols], write_outputs=True)
+    output, photozlist = lp.process(config, input[reduced_cols], write_outputs=False)
     # Check one of the outputs (results are terrible with just one filter and sparse z grid)
     assert np.isclose(output["Z_BEST"][0], 3.5877994546919934)
     assert len(photozlist[0].pdfmap[11].xaxis) == 51


### PR DESCRIPTION
Change the function validLib in onesource.cpp. Rather than providing fullLib as an argument, I passed the redshift from the library. The price for manipulating the large vector of complex objects (fullLib) was slowing down the code. With this modification, we gain almost a factor 3 in speed when zfix=yes. Results are exactly the same. I think that such change could be done in few other functions.