### PR TITLE
Improve some headers and message display

### DIFF
--- a/src/lephare/zphota.py
+++ b/src/lephare/zphota.py
@@ -1,7 +1,5 @@
 import time
 
-import numpy as np
-
 from lephare._lephare import (  # , read_lib, read_doc_filters, readOutKeywords, GalMag, bestFilter, maxkcolor
     GalMag,
     PhotoZ,

--- a/src/lephare/zphota.py
+++ b/src/lephare/zphota.py
@@ -102,9 +102,6 @@ class Zphota(Runner):
         if autoadapt:
             adapt_srcs = photoz.read_autoadapt_sources()
             a0, a1 = photoz.run_autoadapt(adapt_srcs)
-            offsets = ",".join(np.array(a0).astype(str))
-            offsets = "# Offsets from auto-adapt: " + offsets + "\n"
-            photoz.outputHeader += offsets
         else:
             a0 = []
             a1 = []

--- a/src/lib/SED.cpp
+++ b/src/lib/SED.cpp
@@ -41,7 +41,8 @@ SED::SED(const string nameC, int nummodC, string type) {
   sfr = -999;    // SFR (Mo/yr)
   ltir = -999;   // Int_8um^1000um    L_lbda . dlbda    in Log unit Lo
   ebv = 0.;      // E(B-V) applied to the SED
-  extlawId = 0;  // index of the extinction law when dust attenuation has been applied
+  extlawId =
+      0;  // index of the extinction law when dust attenuation has been applied
   chi2 = HIGH_CHI2;  // chi2 of the fit
   dm = -999.;        // Rescaling of the template
   distMod = 0;
@@ -1632,7 +1633,7 @@ void GalSED::writeMag(bool outasc, ofstream &ofsBin, ofstream &ofsDat,
     // Write output
     ofsDat << setw(6) << nummod << " ";
     // start the numbering of attenuation curves at 1 in output
-    ofsDat << setw(3) << extlawId+1 << " ";
+    ofsDat << setw(3) << extlawId + 1 << " ";
     ofsDat << setw(3) << ebv << " ";
     ofsDat << setw(12) << ltir << " ";
     ofsDat << setw(5) << red << " ";
@@ -1894,7 +1895,7 @@ void QSOSED::writeMag(bool outasc, ofstream &ofsBin, ofstream &ofsDat,
     // Write output
     ofsDat << setw(6) << nummod << " ";
     // start the numbering of attenuation curves at 1 in output
-    ofsDat << setw(3) << extlawId+1 << " ";
+    ofsDat << setw(3) << extlawId + 1 << " ";
     ofsDat << setw(3) << ebv << " ";
     ofsDat << setw(5) << red << " ";
     ofsDat << setw(12) << distMod << " ";

--- a/src/lib/SED.cpp
+++ b/src/lib/SED.cpp
@@ -41,8 +41,7 @@ SED::SED(const string nameC, int nummodC, string type) {
   sfr = -999;    // SFR (Mo/yr)
   ltir = -999;   // Int_8um^1000um    L_lbda . dlbda    in Log unit Lo
   ebv = 0.;      // E(B-V) applied to the SED
-  extlawId =
-      0;  // index of the extinction law when dust attenuation has been applied
+  extlawId = 0;  // index of the extinction law when dust attenuation has been applied
   chi2 = HIGH_CHI2;  // chi2 of the fit
   dm = -999.;        // Rescaling of the template
   distMod = 0;
@@ -1632,7 +1631,8 @@ void GalSED::writeMag(bool outasc, ofstream &ofsBin, ofstream &ofsDat,
   if (outasc) {
     // Write output
     ofsDat << setw(6) << nummod << " ";
-    ofsDat << setw(3) << extlawId << " ";
+    // start the numbering of attenuation curves at 1 in output
+    ofsDat << setw(3) << extlawId+1 << " ";
     ofsDat << setw(3) << ebv << " ";
     ofsDat << setw(12) << ltir << " ";
     ofsDat << setw(5) << red << " ";
@@ -1893,7 +1893,8 @@ void QSOSED::writeMag(bool outasc, ofstream &ofsBin, ofstream &ofsDat,
   if (outasc) {
     // Write output
     ofsDat << setw(6) << nummod << " ";
-    ofsDat << setw(3) << extlawId << " ";
+    // start the numbering of attenuation curves at 1 in output
+    ofsDat << setw(3) << extlawId+1 << " ";
     ofsDat << setw(3) << ebv << " ";
     ofsDat << setw(5) << red << " ";
     ofsDat << setw(12) << distMod << " ";

--- a/src/lib/SED.cpp
+++ b/src/lib/SED.cpp
@@ -114,7 +114,8 @@ void SED::read(const string &sedFile) {
   // open the SED template file into a stream
   ssed.open(sedFile.c_str());
   if (!ssed) {
-    throw invalid_argument("Can't open the file with the list of SED to be used " + sedFile);
+    throw invalid_argument(
+        "Can't open the file with the list of SED to be used " + sedFile);
   }
 
   // Take the stream line by line

--- a/src/lib/SED.cpp
+++ b/src/lib/SED.cpp
@@ -114,7 +114,7 @@ void SED::read(const string &sedFile) {
   // open the SED template file into a stream
   ssed.open(sedFile.c_str());
   if (!ssed) {
-    throw invalid_argument("Can't open SED file " + sedFile);
+    throw invalid_argument("Can't open the file with the list of SED to be used " + sedFile);
   }
 
   // Take the stream line by line

--- a/src/lib/SED.h
+++ b/src/lib/SED.h
@@ -172,16 +172,19 @@ class SED {
     ofstream sdocOut, sphysOut, sbinOut;
     sdocOut.open(docFile.c_str());
     if (!sdocOut) {
-      throw invalid_argument("Can't open doc file compiling the SED " + docFile);
+      throw invalid_argument("Can't open doc file compiling the SED " +
+                             docFile);
     }
     sbinOut.open(binFile.c_str(), ios::binary | ios::out);
     if (!sbinOut) {
-      throw invalid_argument("Can't open binary file compiling the SED " + binFile);
+      throw invalid_argument("Can't open binary file compiling the SED " +
+                             binFile);
     }
     if (nlib == GAL) {
       sphysOut.open(physFile.c_str());
       if (!sphysOut) {
-        throw invalid_argument("Can't open physical para file associated to SED " + physFile);
+        throw invalid_argument(
+            "Can't open physical para file associated to SED " + physFile);
       }
     }
     writeSED(sbinOut, sphysOut, sdocOut);
@@ -194,7 +197,8 @@ class SED {
     ifstream sbinIn;
     sbinIn.open(fname.c_str(), ios::binary);
     if (!sbinIn) {
-      throw invalid_argument("Can't open the binary file compiling the SED " + fname);
+      throw invalid_argument("Can't open the binary file compiling the SED " +
+                             fname);
     }
     readSEDBin(sbinIn);
   }

--- a/src/lib/SED.h
+++ b/src/lib/SED.h
@@ -172,16 +172,16 @@ class SED {
     ofstream sdocOut, sphysOut, sbinOut;
     sdocOut.open(docFile.c_str());
     if (!sdocOut) {
-      throw invalid_argument("Can't open doc file " + docFile);
+      throw invalid_argument("Can't open doc file compiling the SED " + docFile);
     }
     sbinOut.open(binFile.c_str(), ios::binary | ios::out);
     if (!sbinOut) {
-      throw invalid_argument("Can't open bin file " + binFile);
+      throw invalid_argument("Can't open binary file compiling the SED " + binFile);
     }
     if (nlib == GAL) {
       sphysOut.open(physFile.c_str());
       if (!sphysOut) {
-        throw invalid_argument("Can't open phys file " + physFile);
+        throw invalid_argument("Can't open physical para file associated to SED " + physFile);
       }
     }
     writeSED(sbinOut, sphysOut, sdocOut);
@@ -194,7 +194,7 @@ class SED {
     ifstream sbinIn;
     sbinIn.open(fname.c_str(), ios::binary);
     if (!sbinIn) {
-      throw invalid_argument("Can't open file " + fname);
+      throw invalid_argument("Can't open the binary file compiling the SED " + fname);
     }
     readSEDBin(sbinIn);
   }

--- a/src/lib/SEDLib.cpp
+++ b/src/lib/SEDLib.cpp
@@ -43,11 +43,11 @@ vector<GalSED> readBC03(string sedFile, int nummod, string type,
   // conversion  from Lum {Lo/A} to flux {erg/cm2/s/A}: fluxconv = 3.197e-07
   double convol = Lsol / (4 * pi * 100 * pow(pc, 2));
 
-  // open the filter file into a stream
+  // open the SED file into a stream
   ssed.open(sedFile.c_str());
   // Check if file is opened
   if (!ssed) {
-    throw invalid_argument("Can't open file " + sedFile);
+    throw invalid_argument("Can't open the BC03 file " + sedFile);
   }
 
   // Number of ages and read the ages

--- a/src/lib/SEDLib.h
+++ b/src/lib/SEDLib.h
@@ -203,20 +203,20 @@ void SEDLib<T>::open_output_files() {
   docFile = lepharework + "/lib_bin/" + libOut + ".doc";
   sdocOut.open(docFile.c_str());
   if (!sdocOut) {
-    throw invalid_argument("Can't open doc file " + docFile);
+    throw invalid_argument("Can't open doc file of the SED library in " + docFile);
   }
 
   binFile = lepharework + "/lib_bin/" + libOut + ".bin";
   sbinOut.open(binFile.c_str(), ios::binary | ios::out);
   if (!sbinOut) {
-    throw invalid_argument("Can't open bin file " + binFile);
+    throw invalid_argument("Can't open binary file of the SED library in " + binFile);
   }
 
   if (typ == "GAL") {
     physFile = lepharework + "/lib_bin/" + libOut + ".phys";
     sphysOut.open(physFile.c_str());
     if (!sphysOut) {
-      throw invalid_argument("Can't open phys file " + physFile);
+      throw invalid_argument("Can't open phys file of the SED library in " + physFile);
     }
   }
 }
@@ -239,7 +239,7 @@ void SEDLib<T>::read_model_list() {
   // open the template list file into a stream
   smod.open(modList.c_str());
   if (!smod) {
-    throw invalid_argument("Can't open mod file " + modList);
+    throw invalid_argument("Can't open file with the list of SED to be used " + modList);
   }
 
   // Take the template list line by line
@@ -290,7 +290,7 @@ void SEDLib<T>::read_age(string ageFich) {
     sage.open(ageFile.c_str());
     // Check if file has opened properly
     if (!sage) {
-      cerr << "Can't open age file " << ageFile << endl;
+      cerr << "Can't open file with the ages to be selected " << ageFile << endl;
       cerr << "No selection by age. " << endl;
       // throw "Failing opening ",ageFile.c_str();
     }

--- a/src/lib/SEDLib.h
+++ b/src/lib/SEDLib.h
@@ -203,20 +203,23 @@ void SEDLib<T>::open_output_files() {
   docFile = lepharework + "/lib_bin/" + libOut + ".doc";
   sdocOut.open(docFile.c_str());
   if (!sdocOut) {
-    throw invalid_argument("Can't open doc file of the SED library in " + docFile);
+    throw invalid_argument("Can't open doc file of the SED library in " +
+                           docFile);
   }
 
   binFile = lepharework + "/lib_bin/" + libOut + ".bin";
   sbinOut.open(binFile.c_str(), ios::binary | ios::out);
   if (!sbinOut) {
-    throw invalid_argument("Can't open binary file of the SED library in " + binFile);
+    throw invalid_argument("Can't open binary file of the SED library in " +
+                           binFile);
   }
 
   if (typ == "GAL") {
     physFile = lepharework + "/lib_bin/" + libOut + ".phys";
     sphysOut.open(physFile.c_str());
     if (!sphysOut) {
-      throw invalid_argument("Can't open phys file of the SED library in " + physFile);
+      throw invalid_argument("Can't open phys file of the SED library in " +
+                             physFile);
     }
   }
 }
@@ -239,7 +242,8 @@ void SEDLib<T>::read_model_list() {
   // open the template list file into a stream
   smod.open(modList.c_str());
   if (!smod) {
-    throw invalid_argument("Can't open file with the list of SED to be used " + modList);
+    throw invalid_argument("Can't open file with the list of SED to be used " +
+                           modList);
   }
 
   // Take the template list line by line
@@ -290,7 +294,8 @@ void SEDLib<T>::read_age(string ageFich) {
     sage.open(ageFile.c_str());
     // Check if file has opened properly
     if (!sage) {
-      cerr << "Can't open file with the ages to be selected " << ageFile << endl;
+      cerr << "Can't open file with the ages to be selected " << ageFile
+           << endl;
       cerr << "No selection by age. " << endl;
       // throw "Failing opening ",ageFile.c_str();
     }

--- a/src/lib/ext.cpp
+++ b/src/lib/ext.cpp
@@ -31,7 +31,7 @@ void ext::read(string extFile) {
   sext.open(extFile.c_str());
   // Check if file is opened
   if (!sext) {
-    throw invalid_argument("Can't open file " + extFile);
+    throw invalid_argument("Can't open file with the attenuation curve in " + extFile);
   }
 
   // Take the stream line by line

--- a/src/lib/ext.cpp
+++ b/src/lib/ext.cpp
@@ -31,7 +31,8 @@ void ext::read(string extFile) {
   sext.open(extFile.c_str());
   // Check if file is opened
   if (!sext) {
-    throw invalid_argument("Can't open file with the attenuation curve in " + extFile);
+    throw invalid_argument("Can't open file with the attenuation curve in " +
+                           extFile);
   }
 
   // Take the stream line by line

--- a/src/lib/flt.cpp
+++ b/src/lib/flt.cpp
@@ -457,7 +457,8 @@ void write_output_filter(string &filtfile, string &filtdoc,
   stfiltdoc.open(filtdoc.c_str());
   // Check if file is opened
   if (!stfiltdoc) {
-    throw invalid_argument("Can't open doc file compiling all filters " + filtdoc);
+    throw invalid_argument("Can't open doc file compiling all filters " +
+                           filtdoc);
   }
 
   // documentation on the screen

--- a/src/lib/flt.cpp
+++ b/src/lib/flt.cpp
@@ -34,7 +34,7 @@ void flt::read(const string &fltFile) {
   // open the filter file into a stream
   sflt.open(fltFile.c_str());
   if (!(sflt)) {
-    throw invalid_argument("Can't open file " + fltFile);
+    throw invalid_argument("Can't open filter file " + fltFile);
   }
 
   // Take the stream line by line
@@ -452,12 +452,12 @@ void write_output_filter(string &filtfile, string &filtdoc,
   stfiltfile.open(filtfile.c_str());
   // Check if file is opened
   if (!stfiltfile) {
-    throw invalid_argument("Can't open file " + filtfile);
+    throw invalid_argument("Can't open file compiling all filters " + filtfile);
   }
   stfiltdoc.open(filtdoc.c_str());
   // Check if file is opened
   if (!stfiltdoc) {
-    throw invalid_argument("Can't open file " + filtdoc);
+    throw invalid_argument("Can't open doc file compiling all filters " + filtdoc);
   }
 
   // documentation on the screen

--- a/src/lib/mag.cpp
+++ b/src/lib/mag.cpp
@@ -107,7 +107,8 @@ void Mag::open_files() {
   ssedIn.open(sedlibFile.c_str(), ios::binary);
   // Check if file is opened
   if (!ssedIn) {
-    throw invalid_argument("Can't open binary file compiling all SEDs " + sedlibFile);
+    throw invalid_argument("Can't open binary file compiling all SEDs " +
+                           sedlibFile);
   }
 
   // Name of the input SED doc file
@@ -118,7 +119,8 @@ void Mag::open_files() {
   sdocOut.open(docFile.c_str());
   // Check if file is opened
   if (!sdocOut) {
-    throw invalid_argument("Can't open the doc file compiling all SEDs " + docFile);
+    throw invalid_argument("Can't open the doc file compiling all SEDs " +
+                           docFile);
   }
 
   // Name of the output binary and doc files, open it in binary
@@ -126,7 +128,8 @@ void Mag::open_files() {
   sbinOut.open(binOutFile.c_str(), ios::binary | ios::out);
   // Check if file is opened
   if (!sbinOut) {
-    throw invalid_argument("Can't open the binary file with the predicted flux " + binOutFile);
+    throw invalid_argument(
+        "Can't open the binary file with the predicted flux " + binOutFile);
   }
 
   // Open an ascii file to store the predicted magnitudes
@@ -136,7 +139,8 @@ void Mag::open_files() {
     sdatOut.open(datFile.c_str());
     // Check if file is opened
     if (!sdatOut) {
-      throw invalid_argument("Can't open the ascii file with the predicted flux " + datFile);
+      throw invalid_argument(
+          "Can't open the ascii file with the predicted flux " + datFile);
     }
 
     sdatOut << "# Filter list: \n";
@@ -250,7 +254,8 @@ void Mag::read_flt(const string &inputfile) {
   sfiltIn.open(inputfile.c_str());
   // Check if file is opened
   if (!sfiltIn) {
-    throw invalid_argument("Can't open file compiling all filters in " + inputfile);
+    throw invalid_argument("Can't open file compiling all filters in " +
+                           inputfile);
   }
 
   string dummy;

--- a/src/lib/mag.cpp
+++ b/src/lib/mag.cpp
@@ -107,7 +107,7 @@ void Mag::open_files() {
   ssedIn.open(sedlibFile.c_str(), ios::binary);
   // Check if file is opened
   if (!ssedIn) {
-    throw invalid_argument("Can't open file " + sedlibFile);
+    throw invalid_argument("Can't open binary file compiling all SEDs " + sedlibFile);
   }
 
   // Name of the input SED doc file
@@ -118,7 +118,7 @@ void Mag::open_files() {
   sdocOut.open(docFile.c_str());
   // Check if file is opened
   if (!sdocOut) {
-    throw invalid_argument("Can't open file " + docFile);
+    throw invalid_argument("Can't open the doc file compiling all SEDs " + docFile);
   }
 
   // Name of the output binary and doc files, open it in binary
@@ -126,7 +126,7 @@ void Mag::open_files() {
   sbinOut.open(binOutFile.c_str(), ios::binary | ios::out);
   // Check if file is opened
   if (!sbinOut) {
-    throw invalid_argument("Can't open file " + binOutFile);
+    throw invalid_argument("Can't open the binary file with the predicted flux " + binOutFile);
   }
 
   // Open an ascii file to store the predicted magnitudes
@@ -136,9 +136,10 @@ void Mag::open_files() {
     sdatOut.open(datFile.c_str());
     // Check if file is opened
     if (!sdatOut) {
-      throw invalid_argument("Can't open file " + datFile);
+      throw invalid_argument("Can't open the ascii file with the predicted flux " + datFile);
     }
 
+    sdatOut << "# Filter list: \n";
     if (allFlt.size() != 0) {
       for (const auto f : allFlt) {
         sdatOut << "#" << f.name << "\n";
@@ -154,7 +155,7 @@ void Mag::open_files() {
             << endl;
         break;
       case object_type::QSO:
-        sdatOut << "# model ext_law E(B-V) L_T(IR) redshift dist_modulus age "
+        sdatOut << "# model ext_law E(B-V) redshift dist_modulus "
                    "N_filt magnitude[N_filt] kcorr[N_filt] "
                 << endl;
         break;
@@ -175,7 +176,7 @@ ifstream Mag::open_opa_files() {
   stream.open(opaListFile.c_str());
   // Check if file is opened
   if (!stream) {
-    throw invalid_argument("Can't open file " + opaListFile);
+    throw invalid_argument("Can't open file with opacity " + opaListFile);
   }
   return stream;
 }
@@ -249,7 +250,7 @@ void Mag::read_flt(const string &inputfile) {
   sfiltIn.open(inputfile.c_str());
   // Check if file is opened
   if (!sfiltIn) {
-    throw invalid_argument("Can't open file " + inputfile);
+    throw invalid_argument("Can't open file compiling all filters in " + inputfile);
   }
 
   string dummy;

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -542,7 +542,9 @@ void onesource::compute_best_fit_physical_quantities(vector<SED *> &fulllib) {
     double age = best_gal_sed->age;
     results["AGE_BEST"] = (age != INVALID_PHYS) ? LOG10D(age) : INVALID_PHYS;
     results["EBV_BEST"] = best_gal_sed->ebv;
-    results["EXTLAW_BEST"] = best_gal_sed->extlawId;
+    // Add +1 to have the first dust attenuation curve starting at 1 in the
+    // output
+    results["EXTLAW_BEST"] = best_gal_sed->extlawId + 1;
     results["LUM_NUV_BEST"] =
         best_gal_sed->luv + LOG10D(3.e18 * 400 / pow(2300, 2) * tmp2);
     results["LUM_R_BEST"] =
@@ -1363,9 +1365,10 @@ void onesource::write_out(vector<SED *> &fulllib, vector<SED *> &fulllibIR,
     // ABSOLUTE MAGNITUDES
     stout.setf(ios::fixed);
     stout.precision(0);  // Integer:
+    // Add +1 to the filter to have the first filter starting at 1 in the output
     if (outkey == "MABS_FILT()") {
       for (size_t l = 0; l < absfilt.size(); l++)
-        stout << setw(4) << absfilt[l] << " ";
+        stout << setw(4) << absfilt[l] + 1 << " ";
     }
     stout.setf(ios::fixed, ios::floatfield);
     stout.precision(3);  // Float:

--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -319,8 +319,8 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
                   to_string(magabsF[0]) + '\n';
   outputHeader += "# MAG_ABS_AGN            : " + to_string(magabsB[1]) + ' ' +
                   to_string(magabsF[1]) + '\n';
-  outputHeader += "# MAG_REF                : " + to_string(babs) + '\n';
-  outputHeader += "# NZ_PRIOR               : " + to_string(bp[0]) + ' ' +
+  outputHeader += "# MAG_REF                : " + to_string(babs + 1) + '\n';
+  outputHeader += "# NZ_PRIOR               : " + to_string(bp[0] + 1) + ' ' +
                   to_string(bp[1]) + '\n';
   outputHeader += "# Z_INTERP               : " + bool2string(zintp) + '\n';
   outputHeader +=
@@ -339,7 +339,7 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
   outputHeader += '\n';
   outputHeader += "# MABS_REF               : ";
   for (int k = 0; k < nbapp; k++) {
-    outputHeader += to_string(bapp[k]) + ' ';
+    outputHeader += to_string(bapp[k] + 1) + ' ';
   };
   outputHeader += '\n';
   // AUTO-ADAPT
@@ -351,7 +351,7 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
   // Need to substract one because the convention in the .para file start at 1,
   // but 0 in the code
   fl_auto--;
-  outputHeader += "# ADAPT_BAND             : " + to_string(fl_auto) + '\n';
+  outputHeader += "# ADAPT_BAND             : " + to_string(fl_auto + 1) + '\n';
   // ADAPT_LIM limit for the selection in auto-adapt
   auto_thresmin = ((key_analysed["ADAPT_LIM"]).split_double("15", 2))[0];
   auto_thresmax = ((key_analysed["ADAPT_LIM"]).split_double("35", 2))[1];

--- a/tests/data/alloutputkeys.txt
+++ b/tests/data/alloutputkeys.txt
@@ -32,7 +32,6 @@ LUM_R_BEST              float         results["LUM_R_BEST"]
 LUM_K_BEST              float         results["LUM_K_BEST"]
 LUM_TIR_BEST            float         results["LUM_TIR_BEST"]
 MOD_BEST                int           imasmin[0]
-#PDZ_BEST
 CHI_BEST                float         chimin[0]
 SCALE_BEST              float         dmmin[0]
 CONTEXT                 long          cont
@@ -89,9 +88,6 @@ LUM_TIR_SUP		float         LIRmed[2]
 MASS_MED                float         massmed[0]
 MASS_INF		float         massmed[1]
 MASS_SUP		float         massmed[2]
-#EBV_MED                 float         med[0]
-#EBV_INF                 float         med[1]
-#EBV_SUP                 float         med[2]
 SFR_MED                 float         SFRmed[0]
 SFR_INF			float         SFRmed[1]
 SFR_SUP			float         SFRmed[2]
@@ -126,7 +122,6 @@ EM_EW_OIIIB             float         results_emission_lines["EM_FLUX_LYA"]
 EM_EW_HA                float         results_emission_lines["EM_FLUX_LYA"]
 EM_EW_SIIIA             float         results_emission_lines["EM_FLUX_LYA"]
 EM_EW_SIIIB             float         results_emission_lines["EM_FLUX_LYA"]
-#MABS_FLUX
 MABS_FILT()             float         absfilt
 K_COR()                 float         kap
 MAG_ABS()               float         mabs


### PR DESCRIPTION
Minor improvements for the display:

- Offsets from auto adapt written twice (once in prep_data, once in zphota.py). Remove one of them.
- More informative error message when a file is missing
- Change the header of the ascii file for the predicted magnitude library
