### PR TITLE
Allow extrapolation of the templates also at higher redshift if the f…

### DIFF
--- a/src/lib/SED.cpp
+++ b/src/lib/SED.cpp
@@ -221,9 +221,8 @@ void SED::warning_integrateSED(const vector<flt> &filters, bool verbose) {
       lamb_flux.emplace(lamb_flux.begin(), 0, 0, 1);
     }
 
-    if ((((lamb_flux.end() - 1)->lamb) * (1. + red) < filter.lmax()) &&
-        (red == 0)) {
-      if (verbose) {
+    if (((lamb_flux.end() - 1)->lamb) * (1. + red) < filter.lmax()) {
+      if (verbose && (red == 0)) {
         cout << "A problem could occur since maximum of SED "
              << (lamb_flux.end() - 1)->lamb << " below max of the filter "
              << filter.lmax();

--- a/src/lib/SED.cpp
+++ b/src/lib/SED.cpp
@@ -224,7 +224,7 @@ void SED::warning_integrateSED(const vector<flt> &filters, bool verbose) {
     if (((lamb_flux.end() - 1)->lamb) * (1. + red) < filter.lmax()) {
       if (verbose && (red == 0)) {
         cout << "A problem could occur since maximum of SED "
-             << (lamb_flux.end() - 1)->lamb << " below max of the filter "
+             << lamb_flux.back().lamb << " below max of the filter "
              << filter.lmax();
         cout << " with filters redder than " << filter.name << " and SED "
              << name << " and z " << red << ".";
@@ -236,7 +236,7 @@ void SED::warning_integrateSED(const vector<flt> &filters, bool verbose) {
       // SED in the red part This is a linear extrapolation from the last point
       // defined in the SED. The extrapolation should be done in the template
       // itself, with a physical meaning. Need to avoid such situation.
-      lamb_flux.emplace_back(1.e8, 0, 1);
+      lamb_flux.emplace_back(1.e8 * (1. + red), 0, 1);
     }
   }
 }

--- a/src/lib/mag.cpp
+++ b/src/lib/mag.cpp
@@ -463,8 +463,6 @@ void GalMag::read_SED() {
     GalSED oneSED("");
     // read one SED in the binary file
     oneSED.readSEDBin(ssedIn);
-    //// Check that the lambda coverage is correct
-    // oneSED.warning_integrateSED(allFlt, verbose);
     // build the library of SEDs that modify the initial template SED
     vector<GalSED> seds = make_maglib(oneSED);
     // write the result in file
@@ -748,8 +746,6 @@ void QSOMag::read_SED() {
     QSOSED oneSED("");
     oneSED.clean();
     oneSED.readSEDBin(ssedIn);
-    //// Check that the lambda coverage is correct
-    // oneSED.warning_integrateSED(allFlt, verbose);
     // build the library of SEDs that modify the initial template SED
     vector<QSOSED> seds = make_maglib(oneSED);
     // write the result in file


### PR DESCRIPTION
Protection against crazy magnitudes is not done in the fitting procedure to avoid loosing time in "if" statement and improve performance of the code.  So, any problematic magnitudes in the model should be catched before in mag_gal.

In mag.cpp, we need to avoid filters which integrate outside the lambda range covered by the SED. So, we extrapolate artificially the SED and put a warning message. It was done in SED::warning_integrateSED, but there was a condition to do it only at z=0 (to avoid to many warning messages). So, we remove this condition to do it at any redshift.

Still, it means that you have templates not extrapolated as red as the W4 filter and that the extrapolation is un-physical.

Raphael, could you try a run with this branch and tell me if it corrected the problem?
