### PR TITLE
275 bug in rm discrepant bd

### DIFF
--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -340,6 +340,11 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
   int number_threads = 1, thread_id = 0;
   size_t imagm = ab.size();
 
+  // Reinitialise the chi2 for each library because the fit could be run several times
+  // on the same source
+  for (int k = 0; k < 3; k++)chimin[k] = HIGH_CHI2;
+  
+
   // Do a local minimisation per thread (store chi2 and index)
   // Catch first the number of threads
 #ifdef _OPENMP
@@ -481,6 +486,13 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
       imasmin[k] = fulllib[indmin[k]]->nummod;
     }
   }
+
+
+  
+  for (size_t i = 0; i < va.size(); i++) {
+      size_t il = va[i];
+      SED *sed = fulllib[il];
+   }
 
   return;
 }
@@ -658,7 +670,13 @@ void onesource::rm_discrepant(vector<SED *> &fulllib,
     } else
       break;
   }
-  return;
+
+  for (size_t i = 0; i < va.size(); i++) {
+      size_t il = va[i];
+      SED *sed = fulllib[il];
+   }
+
+   return;
 }
 
 /*
@@ -849,6 +867,7 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   auto &pdfminzq = pdfmap[10];
   auto &pdfbayzg = pdfmap[11];
   auto &pdfbayzq = pdfmap[12];
+
 
   // parrallellize over each SED
 #ifdef _OPENMP
@@ -1085,6 +1104,7 @@ Compute the mode and the associated uncertainties based on the marginalized
 error
  */
 void onesource::mode() {
+
   // First element of zgmode is the mode of the marginalized PDF
   // Use the parabolic interpolation for galaxies and QSO
   zgmode.push_back(pdfmap[11].int_parabL());

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -340,12 +340,12 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
   int number_threads = 1, thread_id = 0;
   size_t imagm = ab.size();
 
-  // Reinitialise the chi2 for each library because the fit could be run several times
-  // on the same source
-  for (int k = 0; k < 3; k++)chimin[k] = HIGH_CHI2;
+  // Reinitialise the chi2 for each library because the fit could be run several
+  // times on the same source
+  for (int k = 0; k < 3; k++) chimin[k] = HIGH_CHI2;
 
-  // Do a local minimisation per thread (store chi2 and index)
-  // Catch first the number of threads
+    // Do a local minimisation per thread (store chi2 and index)
+    // Catch first the number of threads
 #ifdef _OPENMP
   number_threads = omp_get_max_threads();
 #endif

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -662,8 +662,7 @@ void onesource::rm_discrepant(vector<SED *> &fulllib,
     } else
       break;
   }
-
-   return;
+  return;
 }
 
 /*

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -343,7 +343,7 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
   // Reinitialise the chi2 for each library because the fit could be run several times
   // on the same source
   for (int k = 0; k < 3; k++)chimin[k] = HIGH_CHI2;
-  
+
   // Do a local minimisation per thread (store chi2 and index)
   // Catch first the number of threads
 #ifdef _OPENMP
@@ -853,7 +853,6 @@ void onesource::generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
   auto &pdfminzq = pdfmap[10];
   auto &pdfbayzg = pdfmap[11];
   auto &pdfbayzq = pdfmap[12];
-
 
   // parrallellize over each SED
 #ifdef _OPENMP

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -344,7 +344,6 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
   // on the same source
   for (int k = 0; k < 3; k++)chimin[k] = HIGH_CHI2;
   
-
   // Do a local minimisation per thread (store chi2 and index)
   // Catch first the number of threads
 #ifdef _OPENMP
@@ -486,13 +485,6 @@ void onesource::fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
       imasmin[k] = fulllib[indmin[k]]->nummod;
     }
   }
-
-
-  
-  for (size_t i = 0; i < va.size(); i++) {
-      size_t il = va[i];
-      SED *sed = fulllib[il];
-   }
 
   return;
 }
@@ -670,11 +662,6 @@ void onesource::rm_discrepant(vector<SED *> &fulllib,
     } else
       break;
   }
-
-  for (size_t i = 0; i < va.size(); i++) {
-      size_t il = va[i];
-      SED *sed = fulllib[il];
-   }
 
    return;
 }
@@ -1104,7 +1091,6 @@ Compute the mode and the associated uncertainties based on the marginalized
 error
  */
 void onesource::mode() {
-
   // First element of zgmode is the mode of the marginalized PDF
   // Use the parabolic interpolation for galaxies and QSO
   zgmode.push_back(pdfmap[11].int_parabL());


### PR DESCRIPTION
The problem was the following:

- When RM_DISCREPANT_BD was activated for one object, the fit() is performed a second time.
- In this specific case, the fit was better with the STAR library removing one band X. But this band X was not the ones producing the minimum chi2 for the QSO library.
- Therefore, the code was computing a huge chi2 difference between the chi2 and chi_min for QSO and crazy probabilities, which was creating a problem later when computing the mode of the PDF (bay)

The origin of this problem is that chi2min was not reinitialized at the beginning of fit() since it was done at the construction of the studied source. And with RM_DISCREPANT_BD, fit() could be called several times. In this specific case, it was creating a problem.

I included a line to reinitialize chimin at the beginning of fit().
It solves the problem.
