### PR TITLE
z interpolation should not occur when the fit failed

### DIFF
--- a/src/lib/globals.h
+++ b/src/lib/globals.h
@@ -11,6 +11,8 @@
 #define INVALID_VAL -9999.0
 #define INVALID_MAG -9999.0
 #define INVALID_PHYS -999.0
+#define INVALID_Z -99.9
+#define INVALID_INDEX -99
 #define NULL_FLUX 0.0
 #define HIGH_MAG 1000.0
 #define HIGH_CHI2 1.0e9

--- a/src/lib/onesource.cpp
+++ b/src/lib/onesource.cpp
@@ -1517,12 +1517,16 @@ void onesource::interp(const bool zfix, const bool zintp, const cosmo &lcdm) {
   }
 
   if (zintp) {
-    double target_z_gal = pdfmap[9].int_parab();
-    double target_z_qso = pdfmap[10].int_parab();
-    dmmin[0] *= lcdm.flux_rescaling(zmin[0], target_z_gal);
-    zmin[0] = target_z_gal;
-    dmmin[1] *= lcdm.flux_rescaling(zmin[1], target_z_qso);
-    zmin[1] = target_z_qso;
+    if (zmin[0] != INVALID_Z) {
+      double target_z_gal = pdfmap[9].int_parab();
+      dmmin[0] *= lcdm.flux_rescaling(zmin[0], target_z_gal);
+      zmin[0] = target_z_gal;
+    }
+    if (zmin[1] != INVALID_Z) {
+      double target_z_qso = pdfmap[10].int_parab();
+      dmmin[1] *= lcdm.flux_rescaling(zmin[1], target_z_qso);
+      zmin[1] = target_z_qso;
+    }
     return;
   }
 }

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -83,20 +83,20 @@ class onesource {
 
   // Minimal constructor of the source
   onesource() {
-    spec = "1";  // ident
-    zs = -99.9;  // spectroscopic redshift
-    cont = 0;    // context
+    spec = "1";      // ident
+    zs = INVALID_Z;  // spectroscopic redshift
+    cont = 0;        // context
     str_inp = ' ';
     for (int k = 0; k < 3; k++) {
-      zmin[k] = -99.9;
-      indmin[k] = -99;
+      zmin[k] = INVALID_Z;
+      indmin[k] = INVALID_INDEX;
       chimin[k] = HIGH_CHI2;
-      imasmin[k] = -99;
+      imasmin[k] = INVALID_INDEX;
     }
-    zminIR = -99.9;
-    indminIR = -99;
+    zminIR = INVALID_Z;
+    indminIR = INVALID_INDEX;
     chiminIR = HIGH_CHI2;
-    imasminIR = -99;
+    imasminIR = INVALID_INDEX;
     nbused = 0;
     pos = 0;
   }


### PR DESCRIPTION
interpolation needs to be protected against a failed fit, lest the INVALID_Z=-99.9 becomes z=0, which is bad.