### PR TITLE
Update photoz_lib.cpp changed GLB_CONTEXT default value to -99

### DIFF
--- a/src/lib/photoz_lib.cpp
+++ b/src/lib/photoz_lib.cpp
@@ -103,7 +103,7 @@ PhotoZ::PhotoZ(keymap &key_analysed) {
 
   // GLB_CONTEXT Global context to be used for all objects - 0 default (all
   // bands)
-  gbcont = ((key_analysed["GLB_CONTEXT"]).split_long("0", 1))[0];
+  gbcont = ((key_analysed["GLB_CONTEXT"]).split_long("-99", 1))[0];
 
   // FORB_CONTEXT Context to reject some bands for all sources - 0 default
   contforb = ((key_analysed["FORB_CONTEXT"]).split_long("0", 1))[0];


### PR DESCRIPTION
changed default global context value to -99 in photoz_lib.ccp;  to counteract default value overwriting custom context in input catalog file  
