### PR TITLE
Fix deprecated example

### DIFF
--- a/docs/detailed.rst
+++ b/docs/detailed.rst
@@ -190,7 +190,7 @@ However, we also added a function ``lp.prepare`` which first compute the full pr
   # This line run together all the library preparation 
   lp.prepare(config)
   # Calculate the photometric redshifts
-  output, pdfs, zgrid = lp.process(config, input_table)
+  output, pdfs = lp.process(config, input_table)
 
 
 		

--- a/docs/detailed.rst
+++ b/docs/detailed.rst
@@ -1127,7 +1127,7 @@ You can run the photometric redshift with the function ``lp.process``  prepared 
   # This line run together all the library preparation 
   lp.prepare(config)
   # Calculate the photometric redshifts
-  output, pdfs, zgrid = lp.process(config, input_table)
+  output, pdfs = lp.process(config, input_table)
 
 The ``input_table`` is a python table with a pre-defined format (explained below).
 
@@ -1288,7 +1288,7 @@ There is two different methods to create the input source list and run the photo
   input_table["string_data"] = "arbitrary_info"
 
   # Calculate the photometric redshifts using the function process
-  output, pdfs, zgrid = lp.process(config, input_table)
+  output, pdfs = lp.process(config, input_table)
 
 **Method 2**
 


### PR DESCRIPTION
One danger of code snippets is they don't get tested by doc building. There are only a few snippets but we noticed this one has drifted out of date after a change in process.

I think it is safe to merge this given how trivial it is.
