### PR TITLE
using split template function rather than split_xxx

### DIFF
--- a/src/lib/_bindings.cc
+++ b/src/lib/_bindings.cc
@@ -115,7 +115,17 @@ PYBIND11_MODULE(_lephare, mod) {
       .def("split_bool", &keyword::split_bool)
       .def("__repr__", [](const keyword &a) {
         return "(" + a.name + ", " + a.value + ")";
-      });
+      })
+      .def("split", [](keyword& self, const std::string& default_val,
+		       int nbItems, const std::string& type) {
+        if (type == "int")
+            return py::cast(self.split<int>(default_val, nbItems));
+        else if (type == "str")
+            return py::cast(self.split<std::string>(default_val, nbItems));
+        throw std::invalid_argument("Unsupported type: " + type);
+    }, py::arg("default_val"), py::arg("nbItems"), py::arg("type"));
+
+      ;
 
   mod.def("read_command", [](std::vector<std::string> args) {
     std::vector<char *> cstrs;

--- a/tests/lephare/test_keyword.py
+++ b/tests/lephare/test_keyword.py
@@ -18,6 +18,7 @@ def test_keyword_basic():
     assert k.value == "1"
     # test mismatch in size
     assert np.array_equal(k.split_string("0", 2), ["1", "1"])
+    assert np.array_equal(k.split("0", 2, 'str'), ["1", "1"])
     k = keyword("k3", "1,1")
     assert np.array_equal(k.split_string("0", 3), ["0", "0", "0"])
 
@@ -26,6 +27,7 @@ def test_keyword_array():
     k = keyword("k", "1,1")
     assert np.array_equal(k.split_string("0", 2), ["1", "1"])
     assert np.array_equal(k.split_int("0", 2), [1, 1])
+    assert np.array_equal(k.split("0", 2, 'int'), [1, 1])
     assert np.array_equal(k.split_long("0", 2), [1, 1])
     assert np.array_equal(k.split_bool("0", 2), [True, True])
     assert np.array_equal(k.split_double("0", 2), [1.0, 1.0])


### PR DESCRIPTION
This PR proposes to simplify the split codebase of keyword objects. It is more elegant, and a minor change:
- C++ keyword class already has a `split` template method that does in one shot what all the `split_xxx` classes do, with less boilerplate code so more elegant
- python bindings of course cannot expose template "as is" (id est having a `split<str> kind of syntax). But it can expose it with an added argument, as exemplified in the `_bindings.cc` commit here.
- testing this is trivial and I added two examples in `test_keyword.py`
- this means in the end that we replace all the `split_X` calls in C++ by `split<X>`

I am opening the discussion, before adding the other types to the exposed python function (only string and int for now)