### PR TITLE
Improve cache utilization in onesource::fit

### DIFF
--- a/src/lib/PDF.cpp
+++ b/src/lib/PDF.cpp
@@ -226,7 +226,7 @@ pair<double, double> PDF::confidence_interval(float dchi) {
   // Now we search for the position where the chi2 curve goes above chiLim,
   // right and left from index min_ib, which remains reasonable compared to zmin
   // position Loop over each point of the PDF to find the minimum error
-  for (int k = 0; k < min_ib; k++) {
+  for (size_t k = 0; k < min_ib; k++) {
     // When the considered chi2 is below the chi2 limit and the following one
     // above
     if (chi2[k] >= chiLim && chi2[k + 1] < chiLim) {

--- a/src/lib/mag.cpp
+++ b/src/lib/mag.cpp
@@ -142,7 +142,7 @@ void Mag::open_files() {
 
     sdatOut << "# Filter list: \n";
     if (allFlt.size() != 0) {
-      for (const auto f : allFlt) {
+      for (const auto &f : allFlt) {
         sdatOut << "#" << f.name << "\n";
       }
     }

--- a/src/lib/onesource.h
+++ b/src/lib/onesource.h
@@ -21,7 +21,7 @@
 
 using namespace std;
 
-class SED;
+struct SEDVec;
 
 static vector<string> phys_par_names = {"AGE",  "LDUST", "LIR",  "MASS", "SFR",
                                         "SSFR", "COL1",  "COL2", "MREF"};
@@ -102,7 +102,7 @@ class onesource {
   }
 
   // Need to initialize the PDF in the constructor after the ":"
-  onesource(const int posC, const vector<double> &gridz) : onesource() {
+  onesource(const int posC, const vector<double>& gridz) : onesource() {
     pos = posC;  // position in the file
 
     // 0:["MASS"] / 1:["SFR"] / 2:["SSFR"] / 3:["LDUST"] / 4:["LIR"] / 5:["AGE"]
@@ -173,7 +173,7 @@ class onesource {
   inline bool get_verbosity() const { return verbose; }
 
   // Prototype
-  void readsource(const string &identifier, const vector<double> vals,
+  void readsource(const string& identifier, const vector<double> vals,
                   const vector<double> err_vals, const long context,
                   const double z_spec, const string additional_input);
   void setPriors(const array<double, 2> magabsB,
@@ -181,31 +181,31 @@ class onesource {
   void fltUsed(const long gbcont, const long contforb, const int imagm);
   void fltUsedIR(const long fir_cont, const long fir_scale, const int imagm,
                  vector<flt> allFilters, const double fir_lmin);
-  void convertFlux(const string &catmag, const vector<flt> allFilters);
+  void convertFlux(const string& catmag, const vector<flt> allFilters);
   void rescale_flux_errors(const vector<double> min_err,
                            const vector<double> fac_err);
 
-  void fit(vector<SED *> &fulllib, const vector<vector<double>> &flux,
-           const vector<size_t> &valid, const double &funz0,
-           const array<int, 2> &bp);
-  void fitIR(vector<SED *> &fulllib, const vector<vector<double>> &flux,
-             const vector<size_t> &valid, const int imagm,
+  void fit(SEDVec& fulllib, const vector<vector<double>>& flux,
+           const vector<size_t>& valid, const double& funz0,
+           const array<int, 2>& bp);
+  void fitIR(SEDVec& fulllib, const vector<vector<double>>& flux,
+             const vector<size_t>& valid, const int imagm,
              const string fit_frsc, cosmo lcdm);
   double nzprior(const double luv, const double lnir, const double reds,
                  const array<int, 2> bp);
-  void rm_discrepant(vector<SED *> &fulllib, const vector<vector<double>> &flux,
-                     const vector<size_t> &valid, const double funz0,
+  void rm_discrepant(SEDVec& fulllib, const vector<vector<double>>& flux,
+                     const vector<size_t>& valid, const double funz0,
                      const array<int, 2> bp, double thresholdChi2);
   /*! Write output in the lephare ascii format
    * @param stout: stream object pointing to the output file
    * @param outkeywords: list of keywords to be output
    */
-  void write_out(ofstream &stout, const vector<string> &outkeywords);
+  void write_out(ofstream& stout, const vector<string>& outkeywords);
   void write_pdz_header(vector<string> pdztype,
-                        unordered_map<string, ofstream> &stpdz,
-                        const time_t &ti1);
+                        unordered_map<string, ofstream>& stpdz,
+                        const time_t& ti1);
   void write_pdz(vector<string> pdztype,
-                 unordered_map<string, ofstream> &stpdz);
+                 unordered_map<string, ofstream>& stpdz);
   void convertMag();
   void keepOri();
 
@@ -222,44 +222,41 @@ class onesource {
    * Note that zfix and zintp are not supposed to both be set. In case it
    * happens, zintp is discarded here.
    */
-  void interp(const bool zfix, const bool zintp, const cosmo &lcdm);
+  void interp(const bool zfix, const bool zintp, const cosmo& lcdm);
   void uncertaintiesMin();
   void uncertaintiesBay();
-  void secondpeak(vector<SED *> &fulllib, const double dz_win,
-                  const double min_thres);
-  void generatePDF(vector<SED *> &fulllib, const vector<size_t> &va,
+  void secondpeak(SEDVec& fulllib, const double dz_win, const double min_thres);
+  void generatePDF(SEDVec& fulllib, const vector<size_t>& va,
                    const vector<int> fltColRF, int fltREF, const bool zfix);
-  void generatePDF_IR(vector<SED *> &fulllib);
+  void generatePDF_IR(SEDVec& fulllib);
   void mode();
-  void interp_lib(vector<SED *> &fulllib, const int imagm, cosmo lcdm);
+  void interp_lib(SEDVec& fulllib, const int imagm, cosmo lcdm);
   void adapt_mag(vector<double> a0);
   void substellar(const bool substar, vector<flt> allFilters);
-  void absmag(const vector<vector<int>> &bestFlt,
-              const vector<vector<double>> &maxkcolor, cosmo lcdm,
+  void absmag(const vector<vector<int>>& bestFlt,
+              const vector<vector<double>>& maxkcolor, cosmo lcdm,
               const vector<double> gridz);
-  void writeSpec(vector<SED *> &fulllib, vector<SED *> &fulllibIR, cosmo lcdm,
-                 vector<opa> opaAll, const vector<flt> &allFilters,
+  void writeSpec(SEDVec& fulllib, SEDVec& fulllibIR, cosmo lcdm,
+                 vector<opa> opaAll, const vector<flt>& allFilters,
                  const string outspdir);
   /*! Write out in a Id<source id>.chi file the chi2 of all the templates
    * participating to the fit.
    * @param fulllib : the library of SED objects.
    */
-  void writeFullChi(const vector<SED *> &fulllib);
-  void computePredMag(vector<SED *> &fulllib, cosmo lcdm, vector<opa> opaAll,
+  void writeFullChi(const SEDVec& fulllib);
+  void computePredMag(SEDVec& fulllib, cosmo lcdm, vector<opa> opaAll,
                       vector<flt> allFltAdd);
-  void computePredAbsMag(vector<SED *> &fulllib, cosmo lcdm, vector<opa> opaAll,
+  void computePredAbsMag(SEDVec& fulllib, cosmo lcdm, vector<opa> opaAll,
                          vector<flt> allFltAdd);
-  void computeEmFlux(vector<SED *> &fulllib, cosmo lcdm, vector<opa> opaAll);
-  void limits(vector<SED *> &fulllib, vector<double> &limits_zbin,
-              int limits_ref, vector<int> &limits_sel,
-              vector<double> &limits_cut);
-  pair<vector<double>, vector<double>> best_spec_vec(short sol,
-                                                     vector<SED *> &fulllib,
+  void computeEmFlux(SEDVec& fulllib, cosmo lcdm, vector<opa> opaAll);
+  void limits(SEDVec& fulllib, vector<double>& limits_zbin, int limits_ref,
+              vector<int>& limits_sel, vector<double>& limits_cut);
+  pair<vector<double>, vector<double>> best_spec_vec(short sol, SEDVec& fulllib,
                                                      cosmo lcdm,
                                                      vector<opa> opaAll,
                                                      double minl, double maxl);
 
-  void compute_best_fit_physical_quantities(vector<SED *> &fulllib);
+  void compute_best_fit_physical_quantities(SEDVec& fulllib);
 };
 
 #endif

--- a/src/lib/photoz_lib.h
+++ b/src/lib/photoz_lib.h
@@ -49,7 +49,7 @@ class PhotoZ {
  public:
   vector<vector<double>> flux, fluxIR;
   vector<double> zLib, zLibIR;
-  vector<SED *> fullLib, fullLibIR, lightLib;
+  SEDVec fullLib, fullLibIR;
   vector<flt> allFilters;
   vector<double> gridz;
   vector<string> outkeywords, pdftype;
@@ -58,15 +58,6 @@ class PhotoZ {
   string outputHeader, outpara;
 
   PhotoZ(keymap &key_analysed);
-
-  virtual ~PhotoZ() {
-    for (auto &sed : fullLib) delete sed;
-    for (auto &sed : fullLibIR) delete sed;
-    for (auto &sed : lightLib) delete sed;
-    fullLib.clear();
-    fullLibIR.clear();
-    lightLib.clear();
-  }
 
   vector<double> compute_offsets(vector<onesource *>);
   vector<double> run_autoadapt(vector<onesource *>);
@@ -77,7 +68,7 @@ class PhotoZ {
 
   void write_outputs(vector<onesource *> sources, const time_t &ti1);
 
-  void read_lib(vector<SED *> &fullLib, int &ind, int nummodpre[3],
+  void read_lib(SEDVec &fullLib, int &ind, int nummodpre[3],
                 const string libName, string &filtname, vector<int> emMod,
                 int &babs);
 
@@ -115,15 +106,15 @@ void auto_adapt(const vector<onesource *> adaptSources, vector<double> &a0,
                 int &converge, int &iteration);
 
 vector<vector<int>> bestFilter(int nbFlt, vector<double> gridz,
-                               vector<SED *> fullLib, int method,
+                               const SEDVec &fullLib, int method,
                                vector<long> magabscont, vector<int> bapp,
                                vector<int> bappOp, vector<double> zbmin,
                                vector<double> zbmax);
 
-vector<vector<double>> maxkcolor(vector<double> gridz, vector<SED *> fullLib,
+vector<vector<double>> maxkcolor(vector<double> gridz, const SEDVec &fullLib,
                                  vector<vector<int>> bestFlt);
 
-void minimizekcolor(vector<double> gridz, vector<SED *> fulllib,
+void minimizekcolor(vector<double> gridz, const SEDVec &fulllib,
                     vector<vector<int>> &bestFlt, vector<long> magabscont);
 
 #endif


### PR DESCRIPTION
## Change Description
Create a structure of arrays version of SED that improves cache utilization and thus performance in `onesource::fit`. Closes #382.
- [x] My PR includes a link to the issue that I am addressing



## Solution Description
As described in #382, the layout of SED causes a lot of extra data to be loaded along with the required data, wasting most of the cache line. The structure of arrays object groups SED attributes together so it's more likely that data loaded into cache will be used.


## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation
