### PR TITLE
Check that the value defined for omp_num_threads is meaningful

### DIFF
--- a/src/lephare/__init__.py
+++ b/src/lephare/__init__.py
@@ -10,6 +10,10 @@ dm = DataManager()
 dm.configure_directories()  # noqa: F405
 LEPHAREDIR = dm.LEPHAREDIR
 
+from ._set_omp_num_threads import _set_omp_num_threads
+
+_set_omp_num_threads()
+
 from ._lephare import *
 
 # import explicitly the internal variables and functions

--- a/src/lephare/_set_omp_num_threads.py
+++ b/src/lephare/_set_omp_num_threads.py
@@ -1,0 +1,33 @@
+import multiprocessing
+import os
+
+
+def _set_omp_num_threads():
+    # Check the maximal number of CPUs
+    max_cpus = multiprocessing.cpu_count()
+
+    # If the environment variable is not defined
+    # Take the max between 1 and max_cpus-1
+    if "OMP_NUM_THREADS" not in os.environ:
+        # Si non défini, utilise max(1, max_cpus - 1)
+        omp_num_threads = max(1, max_cpus - 1)
+        os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
+    else:
+        # If the environment variable is defined
+        # Take the max between 1 and max_cpus-1 if out the limits
+        try:
+            user_threads = int(os.environ["OMP_NUM_THREADS"])
+            if user_threads > max_cpus:
+                omp_num_threads = max(1, max_cpus - 1)
+                os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
+            elif user_threads < 1:
+                omp_num_threads = 1
+                os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
+            else:
+                omp_num_threads = user_threads
+        except ValueError:
+            # If not a valid integer
+            omp_num_threads = max(1, max_cpus - 1)
+            os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
+
+    print(f"OMP_NUM_THREADS set to {os.environ['OMP_NUM_THREADS']} (max available CPUs: {max_cpus})")

--- a/src/lephare/_set_omp_num_threads.py
+++ b/src/lephare/_set_omp_num_threads.py
@@ -4,7 +4,10 @@ import os
 
 def _set_omp_num_threads():
     # Check the maximal number of CPUs
-    max_cpus = multiprocessing.cpu_count()
+    try:
+        max_cpus = multiprocessing.cpu_count()
+    except NotImplementedError:  # pragma no cover
+        return
 
     # If the environment variable is not defined
     # Take the max between 1 and max_cpus-1

--- a/tests/lephare/test_omp_setting.py
+++ b/tests/lephare/test_omp_setting.py
@@ -1,17 +1,19 @@
-import os
 import importlib
 import multiprocessing
+import os
+
 
 def test_omp_setting():
     max_cpus = multiprocessing.cpu_count()
-    os.environ["OMP_NUM_THREADS"] = "5"
+    os.environ["OMP_NUM_THREADS"] = "1"
     import lephare as lp
-    assert os.environ["OMP_NUM_THREADS"] == "5"
+
+    assert os.environ["OMP_NUM_THREADS"] == "1"
 
     os.environ["OMP_NUM_THREADS"] = "-5"
     importlib.reload(lp)
-    assert os.environ["OMP_NUM_THREADS"] == "1" 
+    assert os.environ["OMP_NUM_THREADS"] == "1"
 
     os.environ["OMP_NUM_THREADS"] = "50"
     importlib.reload(lp)
-    assert os.environ["OMP_NUM_THREADS"] == str(max_cpus - 1)
+    assert os.environ["OMP_NUM_THREADS"] == str(max(1, max_cpus - 1))

--- a/tests/lephare/test_omp_setting.py
+++ b/tests/lephare/test_omp_setting.py
@@ -1,0 +1,17 @@
+import os
+import importlib
+import multiprocessing
+
+def test_omp_setting():
+    max_cpus = multiprocessing.cpu_count()
+    os.environ["OMP_NUM_THREADS"] = "5"
+    import lephare as lp
+    assert os.environ["OMP_NUM_THREADS"] == "5"
+
+    os.environ["OMP_NUM_THREADS"] = "-5"
+    importlib.reload(lp)
+    assert os.environ["OMP_NUM_THREADS"] == "1" 
+
+    os.environ["OMP_NUM_THREADS"] = "50"
+    importlib.reload(lp)
+    assert os.environ["OMP_NUM_THREADS"] == str(max_cpus - 1)


### PR DESCRIPTION

If OMP_NUM_THREADS is not defined, use the maximum between 1 and the maximum number of CPU -1.

If OMP_NUM_THREADS is defined but not meaningful (<1 or >maximum number of CPU ), then use the max between 1 and the maximum number of CPU -1.